### PR TITLE
Update Cargo.toml to change bevy_openxr to bevy_oxr in GitHub link

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "bevy_oxr"
 version = "0.1.0"
 edition = "2021"
 description = "Community crate for OpenXR in Bevy"
-repository = "https://github.com/awtterpip/bevy_openxr"
+repository = "https://github.com/awtterpip/bevy_oxr"
 license = "MIT/Apache-2.0"
 
 


### PR DESCRIPTION
Just 1 commit to fix the repository link