### PR TITLE
Add run condition to fix panic when oculus controller is not used in globe example

### DIFF
--- a/examples/globe.rs
+++ b/examples/globe.rs
@@ -4,6 +4,7 @@ use bevy::render::render_asset::RenderAssetUsages;
 use bevy::transform::components::Transform;
 use bevy_oxr::graphics::XrAppInfo;
 use bevy_oxr::resources::XrViews;
+use bevy_oxr::xr_init::xr_only;
 use bevy_oxr::xr_input::hands::common::HandInputDebugRenderer;
 use bevy_oxr::xr_input::interactions::{
     InteractionEvent, XRDirectInteractor, XRInteractorState, XRRayInteractor, XRSocketInteractor,
@@ -29,7 +30,7 @@ fn main() {
         })
         .add_plugins(LogDiagnosticsPlugin::default())
         .add_systems(Startup, setup)
-        .add_systems(Update, (proto_locomotion, pull_to_ground).chain())
+        .add_systems(Update, (proto_locomotion, pull_to_ground).chain().run_if(xr_only()))
         .insert_resource(PrototypeLocomotionConfig::default())
         .add_systems(Startup, spawn_controllers_example)
         .add_plugins(HandInputDebugRenderer)


### PR DESCRIPTION
Globe example panics when not using oculus touch controller. Adding  `.run_if(xr_only())` like in xr example fixes the issue. 

Related issue #77 