### PR TITLE
Disabled VSync on Android

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,7 +316,10 @@ impl PluginGroup for DefaultXrPlugins {
                     ..default()
                 }),
                 #[cfg(target_os = "android")]
-                primary_window: None, // ?
+                primary_window: Some(Window {
+                    present_mode: PresentMode::AutoNoVsync,
+                    ..default()
+                }),
                 #[cfg(target_os = "android")]
                 exit_condition: bevy::window::ExitCondition::DontExit,
                 #[cfg(target_os = "android")]


### PR DESCRIPTION
VSync limits the max FPS to 60 on Quest 3. This PR disables VSync, allowing FPS up to 90-100 (tested in the android example).