### PR TITLE
fix android "null pointer dereference"

### DIFF
--- a/crates/bevy_openxr/src/openxr/init.rs
+++ b/crates/bevy_openxr/src/openxr/init.rs
@@ -200,6 +200,9 @@ impl OxrInitPlugin {
     fn init_xr(&self) -> Result<(OxrInstance, OxrSystemId, WgpuGraphics, SessionConfigInfo)> {
         let entry = xr_entry()?;
 
+        #[cfg(target_os = "android")]
+        entry.initialize_android_loader()?;
+
         let available_exts = entry.enumerate_extensions()?;
 
         // check available extensions and send a warning for any wanted extensions that aren't available.


### PR DESCRIPTION
Without this line, when compiles to android, it will immediately crash after app started. after adding this line, issue resolved. 