### PR TITLE
add 'vulkan-portability' feature to wgpu when target family is unix (MacOS support)

### DIFF
--- a/crates/bevy_openxr/Cargo.toml
+++ b/crates/bevy_openxr/Cargo.toml
@@ -24,6 +24,7 @@ ash = { version = "0.37.3", optional = true }
 
 [target.'cfg(target_family = "unix")'.dependencies]
 openxr = { version = "0.18.0", features = ["mint"] }
+wgpu = { version = "0.19.3", features = ["vulkan-portability"] }
 
 [target.'cfg(target_family = "windows")'.dependencies]
 openxr = { version = "0.18.0", features = ["mint", "static"] }


### PR DESCRIPTION
idk if anyone else with a mac has run into this issue, but there errors inside of [vulkan.rs](https://github.com/awtterpip/bevy_oxr/blob/3654b36e76d51aa53e0ceff7a700c1b166a5c98b/crates/bevy_openxr/src/openxr/graphics/vulkan.rs). Specifically at `use wgpu_hal::api::Vulkan;`, i get 

```
 unresolved import `wgpu_hal::api::Vulkan`
   no `Vulkan` in `api`
   ```
and then it when diving into the crate, it says Vulkan has been configured out.

I do have the VulkanSDK installed + MoltenVK, yet the same error. So this seems to be easiest way to use vulkan on a mac...? 