### PR TITLE
implement session creators

### DIFF
--- a/crates/bevy_openxr/src/openxr/features/passthrough.rs
+++ b/crates/bevy_openxr/src/openxr/features/passthrough.rs
@@ -1,10 +1,11 @@
 use bevy::prelude::*;
-use bevy::render::Render;
-use bevy::render::RenderApp;
-use bevy::render::RenderSet;
 use openxr::sys::SystemPassthroughProperties2FB;
 use openxr::PassthroughCapabilityFlagsFB;
+use openxr::PassthroughFlagsFB;
+use openxr::PassthroughLayerPurposeFB;
 
+use crate::init::OxrSessionResourceCreator;
+use crate::init::OxrSessionResourceCreatorsApp;
 use crate::layer_builder::PassthroughLayer;
 use crate::resources::*;
 use crate::types::*;
@@ -24,33 +25,58 @@ impl Plugin for OxrPassthroughPlugin {
         if resources.is_some_and(|(instance, system)| {
             supports_passthrough(instance, *system).is_ok_and(|s| s)
         }) {
-            app.sub_app_mut(RenderApp).add_systems(
-                Render,
-                insert_passthrough
-                    .in_set(RenderSet::PrepareAssets)
-                    .run_if(resource_added::<OxrSession>),
-            );
+            app.add_xr_resource_creator(OxrPassthroughCreator {
+                flags: PassthroughFlagsFB::IS_RUNNING_AT_CREATION,
+                purpose: PassthroughLayerPurposeFB::RECONSTRUCTION,
+                layer: None,
+                passthrough: None,
+            });
         } else {
             error!("Passthrough is not supported with this runtime")
         }
     }
 }
 
-pub fn insert_passthrough(world: &mut World) {
-    let session = world.resource::<OxrSession>();
+struct OxrPassthroughCreator {
+    flags: PassthroughFlagsFB,
+    purpose: PassthroughLayerPurposeFB,
+    layer: Option<OxrPassthroughLayer>,
+    passthrough: Option<OxrPassthrough>,
+}
 
-    let (passthrough, passthrough_layer) = create_passthrough(
-        session,
-        openxr::PassthroughFlagsFB::IS_RUNNING_AT_CREATION,
-        openxr::PassthroughLayerPurposeFB::RECONSTRUCTION,
-    )
-    .unwrap();
+impl OxrSessionResourceCreator for OxrPassthroughCreator {
+    fn initialize(&mut self, world: &mut World) -> Result<()> {
+        let session = world.resource::<OxrSession>();
 
-    world
-        .resource_mut::<OxrRenderLayers>()
-        .insert(0, Box::new(PassthroughLayer));
-    world.insert_resource(passthrough);
-    world.insert_resource(passthrough_layer);
+        let passthrough = session.create_passthrough(self.flags)?;
+
+        let layer = session.create_passthrough_layer(&passthrough, self.purpose)?;
+
+        self.layer = Some(layer);
+        self.passthrough = Some(passthrough);
+
+        Ok(())
+    }
+
+    fn insert_to_world(&mut self, _: &mut World) {}
+
+    fn insert_to_render_world(&mut self, world: &mut World) {
+        world.insert_resource(self.passthrough.take().unwrap());
+        world.insert_resource(self.layer.take().unwrap());
+
+        world
+            .resource_mut::<OxrRenderLayers>()
+            .insert(0, Box::new(PassthroughLayer));
+    }
+
+    fn remove_from_world(&mut self, _: &mut World) {}
+
+    fn remove_from_render_world(&mut self, world: &mut World) {
+        world.remove_resource::<OxrPassthrough>();
+        world.remove_resource::<OxrPassthroughLayer>();
+
+        // we don't worry about removing the passthrough render layer here, because it should be done automatically when the session is destroyed
+    }
 }
 
 pub fn resume_passthrough(
@@ -69,30 +95,18 @@ pub fn pause_passthrough(
     passthrough.pause().unwrap();
 }
 
-pub fn create_passthrough(
-    session: &OxrSession,
-    flags: openxr::PassthroughFlagsFB,
-    purpose: openxr::PassthroughLayerPurposeFB,
-) -> Result<(OxrPassthrough, OxrPassthroughLayer)> {
-    let passthrough = session.create_passthrough(flags)?;
-
-    let passthrough_layer = session.create_passthrough_layer(&passthrough, purpose)?;
-
-    Ok((passthrough, passthrough_layer))
-}
-
 #[inline]
 pub fn supports_passthrough(instance: &OxrInstance, system: OxrSystemId) -> Result<bool> {
     if instance.exts().fb_passthrough.is_none() {
         return Ok(false);
     }
     unsafe {
-        let mut hand = openxr::sys::SystemPassthroughProperties2FB {
+        let mut passthrough = openxr::sys::SystemPassthroughProperties2FB {
             ty: SystemPassthroughProperties2FB::TYPE,
             next: std::ptr::null(),
             capabilities: PassthroughCapabilityFlagsFB::PASSTHROUGH_CAPABILITY,
         };
-        let mut p = openxr::sys::SystemProperties::out(&mut hand as *mut _ as _);
+        let mut p = openxr::sys::SystemProperties::out(&mut passthrough as *mut _ as _);
         cvt((instance.fp().get_system_properties)(
             instance.as_raw(),
             system.0,
@@ -100,10 +114,10 @@ pub fn supports_passthrough(instance: &OxrInstance, system: OxrSystemId) -> Resu
         ))?;
         bevy::log::info!(
             "From supports_passthrough: Passthrough capabilities: {:?}",
-            hand.capabilities
+            passthrough.capabilities
         );
         Ok(
-            (hand.capabilities & PassthroughCapabilityFlagsFB::PASSTHROUGH_CAPABILITY)
+            (passthrough.capabilities & PassthroughCapabilityFlagsFB::PASSTHROUGH_CAPABILITY)
                 == PassthroughCapabilityFlagsFB::PASSTHROUGH_CAPABILITY,
         )
     }

--- a/crates/bevy_openxr/src/openxr/init.rs
+++ b/crates/bevy_openxr/src/openxr/init.rs
@@ -218,6 +218,7 @@ impl Plugin for OxrInitPlugin {
                     .insert_resource(cleanup_session)
                     .init_resource::<OxrRootTransform>()
                     .init_resource::<OxrCleanupSession>()
+                    .init_resource::<OxrRenderLayers>()
                     .add_systems(Render, handle_xr_events_render.in_set(OxrPollMain));
             }
             Err(e) => {
@@ -392,6 +393,7 @@ impl OxrSessionResourceCreator for OxrSessionResources {
     fn remove_from_render_world(&mut self, world: &mut World) {
         world.remove_resource::<OxrSession>();
         world.remove_resource::<OxrFrameStream>();
+        world.resource_mut::<OxrRenderLayers>().clear();
     }
 }
 

--- a/crates/bevy_openxr/src/openxr/init.rs
+++ b/crates/bevy_openxr/src/openxr/init.rs
@@ -401,10 +401,10 @@ pub fn create_xr_session_resources(world: &mut World) {
     let resource_creators = world.resource::<OxrSessionResourceCreators>().clone();
     let mut resource_creators_mut = resource_creators.0.lock().unwrap();
 
-    for (resource_creator, initialized) in &mut resource_creators_mut.0 {
+    for (resource_creator, initialization_succeeded) in &mut resource_creators_mut.0 {
         match resource_creator.initialize(world) {
             Ok(_) => {
-                *initialized = true;
+                *initialization_succeeded = true;
                 resource_creator.insert_to_world(world);
             }
             Err(e) => error!(
@@ -414,6 +414,7 @@ pub fn create_xr_session_resources(world: &mut World) {
             ),
         }
     }
+    // This signifies to the render world that a new session has been created and that it should attempt to insert any render resources
     resource_creators_mut.1 = true;
 }
 

--- a/crates/bevy_openxr/src/openxr/layer_builder.rs
+++ b/crates/bevy_openxr/src/openxr/layer_builder.rs
@@ -8,7 +8,7 @@ use crate::reference_space::OxrPrimaryReferenceSpace;
 use crate::resources::*;
 
 pub trait LayerProvider {
-    fn get<'a>(&'a self, world: &'a World) -> Box<dyn CompositionLayer + '_>;
+    fn get<'a>(&'a self, world: &'a World) -> Option<Box<dyn CompositionLayer + '_>>;
 }
 
 pub struct ProjectionLayer;
@@ -16,7 +16,7 @@ pub struct ProjectionLayer;
 pub struct PassthroughLayer;
 
 impl LayerProvider for ProjectionLayer {
-    fn get<'a>(&self, world: &'a World) -> Box<dyn CompositionLayer<'a> + 'a> {
+    fn get<'a>(&self, world: &'a World) -> Option<Box<dyn CompositionLayer<'a> + 'a>> {
         let stage = world.resource::<OxrPrimaryReferenceSpace>();
         let openxr_views = world.resource::<OxrViews>();
         let swapchain = world.resource::<OxrSwapchain>();
@@ -29,7 +29,11 @@ impl LayerProvider for ProjectionLayer {
             },
         };
 
-        Box::new(
+        if openxr_views.len() < 2 {
+            return None;
+        }
+
+        Some(Box::new(
             CompositionLayerProjection::new()
                 .layer_flags(CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA)
                 .space(&stage)
@@ -53,17 +57,17 @@ impl LayerProvider for ProjectionLayer {
                                 .image_rect(rect),
                         ),
                 ]),
-        )
+        ))
     }
 }
 
 impl LayerProvider for PassthroughLayer {
-    fn get<'a>(&'a self, world: &'a World) -> Box<dyn CompositionLayer + '_> {
-        Box::new(
+    fn get<'a>(&'a self, world: &'a World) -> Option<Box<dyn CompositionLayer + '_>> {
+        Some(Box::new(
             CompositionLayerPassthrough::new()
                 .layer_handle(world.resource::<OxrPassthroughLayer>())
                 .layer_flags(CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA),
-        )
+        ))
     }
 }
 

--- a/crates/bevy_openxr/src/openxr/reference_space.rs
+++ b/crates/bevy_openxr/src/openxr/reference_space.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use bevy::prelude::*;
 
 use crate::{
-    init::{OxrSessionResourceCreator, OxrSessionResourceCreators},
+    init::{OxrSessionResourceCreator, OxrSessionResourceCreatorsApp},
     resources::OxrSession,
     types::Result,
 };
@@ -23,7 +23,7 @@ impl Default for OxrReferenceSpacePlugin {
 struct OxrPrimaryReferenceSpaceCreator(openxr::ReferenceSpaceType, Option<Arc<openxr::Space>>);
 
 impl OxrSessionResourceCreator for OxrPrimaryReferenceSpaceCreator {
-    fn update(&mut self, world: &mut World) -> Result<()> {
+    fn initialize(&mut self, world: &mut World) -> Result<()> {
         let session = world.resource::<OxrSession>();
         let space = session.create_reference_space(self.0, openxr::Posef::IDENTITY)?;
         self.1 = Some(Arc::new(space));
@@ -57,11 +57,9 @@ pub struct OxrReferenceSpace(pub openxr::Space);
 
 impl Plugin for OxrReferenceSpacePlugin {
     fn build(&self, app: &mut App) {
-        app.world
-            .resource::<OxrSessionResourceCreators>()
-            .add_resource_creator(OxrPrimaryReferenceSpaceCreator(
-                self.default_primary_ref_space,
-                None,
-            ));
+        app.add_xr_resource_creator(OxrPrimaryReferenceSpaceCreator(
+            self.default_primary_ref_space,
+            None,
+        ));
     }
 }

--- a/crates/bevy_openxr/src/openxr/render.rs
+++ b/crates/bevy_openxr/src/openxr/render.rs
@@ -1,64 +1,73 @@
+use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
+
 use bevy::{
-    ecs::query::QuerySingleError,
+    ecs::{query::QuerySingleError, schedule::SystemConfigs},
     prelude::*,
     render::{
         camera::{ManualTextureView, ManualTextureViewHandle, ManualTextureViews, RenderTarget},
-        extract_resource::ExtractResourcePlugin,
-        renderer::render_system,
+        renderer::{render_system, RenderDevice},
         view::ExtractedView,
         Render, RenderApp, RenderSet,
     },
-    transform::TransformSystem,
+    utils::synccell::SyncCell,
 };
-use bevy_xr::{
-    camera::{XrCamera, XrCameraBundle, XrProjection},
-    session::session_running,
-};
+use bevy_xr::camera::{XrCamera, XrCameraBundle, XrProjection};
 use openxr::ViewStateFlags;
 
 use crate::{
-    init::{session_started, OxrPreUpdateSet, OxrTrackingRoot},
+    error::OxrError,
+    init::{
+        session_started, OxrPreUpdateSet, OxrSessionResourceCreator, OxrSessionResourceCreators,
+        OxrTrackingRoot,
+    },
     layer_builder::ProjectionLayer,
 };
-use crate::{reference_space::OxrPrimaryReferenceSpace, resources::*};
+use crate::{reference_space::OxrPrimaryReferenceSpace, resources::*, types::*};
+
+fn update_view_systems() -> SystemConfigs {
+    (
+        locate_views,
+        update_views.run_if(resource_exists::<OxrViews>),
+    )
+        .chain()
+        .run_if(session_started)
+}
 
 pub struct OxrRenderPlugin;
 
 impl Plugin for OxrRenderPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins((ExtractResourcePlugin::<OxrViews>::default(),))
-            .add_systems(
-                PreUpdate,
-                (
-                    init_views.run_if(resource_added::<OxrGraphicsInfo>),
-                    locate_views.run_if(session_running),
-                    update_views.run_if(session_running),
-                )
-                    .chain()
-                    .after(OxrPreUpdateSet::UpdateNonCriticalComponents),
+        app.world
+            .resource::<OxrSessionResourceCreators>()
+            .init_resource_creator::<OxrSwapchainCreator>();
+        app.add_systems(
+            PreUpdate,
+            wait_frame
+                .run_if(session_started)
+                .in_set(OxrPreUpdateSet::WaitFrame),
+        )
+        .add_systems(
+            PreUpdate,
+            (
+                init_views.run_if(resource_added::<OxrGraphicsInfo>),
+                update_view_systems(),
             )
-            .add_systems(
-                PostUpdate,
-                (locate_views, update_views)
-                    .chain()
-                    .run_if(session_running)
-                    .before(TransformSystem::TransformPropagate),
-            )
-            .add_systems(Last, wait_frame.run_if(session_started));
+                .chain()
+                .after(OxrPreUpdateSet::UpdateNonCriticalComponents),
+        );
+
         app.sub_app_mut(RenderApp)
             .add_systems(
                 Render,
                 (
                     (
+                        begin_frame,
                         insert_texture_views,
                         locate_views.run_if(resource_exists::<OxrPrimaryReferenceSpace>),
                         update_views_render_world,
                     )
                         .chain()
                         .in_set(RenderSet::PrepareAssets),
-                    begin_frame
-                        .before(RenderSet::Queue)
-                        .before(insert_texture_views),
                     wait_image.in_set(RenderSet::Render).before(render_system),
                     (release_image, end_frame)
                         .chain()
@@ -66,7 +75,156 @@ impl Plugin for OxrRenderPlugin {
                 )
                     .run_if(session_started),
             )
+            .insert_resource(OxrViews(vec![]))
             .insert_resource(OxrRenderLayers(vec![Box::new(ProjectionLayer)]));
+    }
+}
+
+#[derive(Default)]
+struct OxrSwapchainCreator {
+    swapchain: Option<OxrSwapchain>,
+    images: Option<OxrSwapchainImages>,
+    graphics_info: Option<OxrGraphicsInfo>,
+}
+
+impl OxrSessionResourceCreator for OxrSwapchainCreator {
+    fn update(&mut self, world: &mut World) -> Result<()> {
+        let instance = world.resource::<OxrInstance>();
+        let system_id = **world.resource::<OxrSystemId>();
+        let session_config_info = world.non_send_resource::<OxrSessionConfigInfo>();
+        let session = world.resource::<OxrSession>();
+        let device = world.resource::<RenderDevice>().wgpu_device();
+
+        // TODO!() support other view configurations
+        let available_view_configurations = instance.enumerate_view_configurations(system_id)?;
+        if !available_view_configurations.contains(&openxr::ViewConfigurationType::PRIMARY_STEREO) {
+            return Err(OxrError::NoAvailableViewConfiguration);
+        }
+
+        let view_configuration_type = openxr::ViewConfigurationType::PRIMARY_STEREO;
+
+        let view_configuration_views =
+            instance.enumerate_view_configuration_views(system_id, view_configuration_type)?;
+
+        let (resolution, _view) = if let Some(resolutions) = &session_config_info.resolutions {
+            let mut preferred = None;
+            for resolution in resolutions {
+                for view_config in view_configuration_views.iter() {
+                    if view_config.recommended_image_rect_height == resolution.y
+                        && view_config.recommended_image_rect_width == resolution.x
+                    {
+                        preferred = Some((*resolution, *view_config));
+                    }
+                }
+            }
+
+            if preferred.is_none() {
+                for resolution in resolutions {
+                    for view_config in view_configuration_views.iter() {
+                        if view_config.max_image_rect_height >= resolution.y
+                            && view_config.max_image_rect_width >= resolution.x
+                        {
+                            preferred = Some((*resolution, *view_config));
+                        }
+                    }
+                }
+            }
+
+            preferred
+        } else {
+            view_configuration_views.first().map(|config| {
+                (
+                    UVec2::new(
+                        config.recommended_image_rect_width,
+                        config.recommended_image_rect_height,
+                    ),
+                    *config,
+                )
+            })
+        }
+        .ok_or(OxrError::NoAvailableViewConfiguration)?;
+
+        let available_formats = session.enumerate_swapchain_formats()?;
+
+        let format = if let Some(formats) = &session_config_info.formats {
+            let mut format = None;
+            for wanted_format in formats {
+                if available_formats.contains(wanted_format) {
+                    format = Some(*wanted_format);
+                }
+            }
+            format
+        } else {
+            available_formats.first().copied()
+        }
+        .ok_or(OxrError::NoAvailableFormat)?;
+
+        let swapchain = session.create_swapchain(SwapchainCreateInfo {
+            create_flags: SwapchainCreateFlags::EMPTY,
+            usage_flags: SwapchainUsageFlags::COLOR_ATTACHMENT | SwapchainUsageFlags::SAMPLED,
+            format,
+            // TODO() add support for multisampling
+            sample_count: 1,
+            width: resolution.x,
+            height: resolution.y,
+            face_count: 1,
+            array_size: 2,
+            mip_count: 1,
+        })?;
+
+        let images = swapchain.enumerate_images(device, format, resolution)?;
+
+        let available_blend_modes =
+            instance.enumerate_environment_blend_modes(system_id, view_configuration_type)?;
+
+        // blend mode selection
+        let blend_mode = if let Some(wanted_blend_modes) = &session_config_info.blend_modes {
+            let mut blend_mode = None;
+            for wanted_blend_mode in wanted_blend_modes {
+                if available_blend_modes.contains(wanted_blend_mode) {
+                    blend_mode = Some(*wanted_blend_mode);
+                    break;
+                }
+            }
+            blend_mode
+        } else {
+            available_blend_modes.first().copied()
+        }
+        .ok_or(OxrError::NoAvailableBackend)?;
+
+        let graphics_info = OxrGraphicsInfo {
+            blend_mode,
+            resolution,
+            format,
+        };
+
+        self.swapchain = Some(swapchain);
+        self.images = Some(images);
+        self.graphics_info = Some(graphics_info);
+
+        Ok(())
+    }
+
+    fn insert_to_world(&mut self, world: &mut World) {
+        world.insert_resource(self.graphics_info.clone().unwrap());
+        world.insert_resource(self.images.clone().unwrap());
+    }
+
+    fn insert_to_render_world(&mut self, world: &mut World) {
+        world.insert_resource(self.graphics_info.take().unwrap());
+        world.insert_resource(self.images.take().unwrap());
+        world.insert_resource(self.swapchain.take().unwrap());
+    }
+
+    fn remove_from_world(&mut self, world: &mut World) {
+        world.remove_resource::<OxrGraphicsInfo>();
+        world.remove_resource::<OxrSwapchainImages>();
+    }
+
+    fn remove_from_render_world(&mut self, world: &mut World) {
+        world.remove_resource::<OxrGraphicsInfo>();
+        world.remove_resource::<OxrSwapchainImages>();
+        world.remove_resource::<OxrSwapchain>();
     }
 }
 
@@ -143,9 +301,6 @@ pub fn locate_views(
             &ref_space,
         )
         .expect("Failed to locate views");
-    if openxr_views.len() != xr_views.len() {
-        openxr_views.resize(xr_views.len(), default());
-    }
     match (
         flags & ViewStateFlags::ORIENTATION_VALID == ViewStateFlags::ORIENTATION_VALID,
         flags & ViewStateFlags::POSITION_VALID == ViewStateFlags::POSITION_VALID,
@@ -153,12 +308,18 @@ pub fn locate_views(
         (true, true) => *openxr_views = OxrViews(xr_views),
         (true, false) => {
             for (i, view) in openxr_views.iter_mut().enumerate() {
-                view.pose.orientation = xr_views[i].pose.orientation;
+                let Some(xr_view) = xr_views.get(i) else {
+                    break;
+                };
+                view.pose.orientation = xr_view.pose.orientation;
             }
         }
         (false, true) => {
             for (i, view) in openxr_views.iter_mut().enumerate() {
-                view.pose.position = xr_views[i].pose.position;
+                let Some(xr_view) = xr_views.get(i) else {
+                    break;
+                };
+                view.pose.position = xr_view.pose.position;
             }
         }
         (false, false) => {}
@@ -373,7 +534,9 @@ pub fn end_frame(world: &mut World) {
     world.resource_scope::<OxrFrameStream, ()>(|world, mut frame_stream| {
         let mut layers = vec![];
         for layer in world.resource::<OxrRenderLayers>().iter() {
-            layers.push(layer.get(world));
+            if let Some(comp_layer) = layer.get(world) {
+                layers.push(comp_layer);
+            }
         }
         let layers: Vec<_> = layers.iter().map(Box::as_ref).collect();
         frame_stream
@@ -385,51 +548,3 @@ pub fn end_frame(world: &mut World) {
             .expect("Failed to end frame");
     });
 }
-
-// pub fn end_frame(
-//     mut frame_stream: ResMut<OxrFrameStream>,
-//     mut swapchain: ResMut<OxrSwapchain>,
-//     stage: Res<OxrStage>,
-//     display_time: Res<OxrTime>,
-//     graphics_info: Res<OxrGraphicsInfo>,
-//     openxr_views: Res<OxrViews>,
-// ) {
-//     let _span = info_span!("xr_end_frame");
-//     swapchain.release_image().unwrap();
-//     let rect = openxr::Rect2Di {
-//         offset: openxr::Offset2Di { x: 0, y: 0 },
-//         extent: openxr::Extent2Di {
-//             width: graphics_info.resolution.x as _,
-//             height: graphics_info.resolution.y as _,
-//         },
-//     };
-//     frame_stream
-//         .end(
-//             **display_time,
-//             graphics_info.blend_mode,
-//             &[&CompositionLayerProjection::new()
-//                 .layer_flags(CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA)
-//                 .space(&stage)
-//                 .views(&[
-//                     CompositionLayerProjectionView::new()
-//                         .pose(openxr_views.0[0].pose)
-//                         .fov(openxr_views.0[0].fov)
-//                         .sub_image(
-//                             SwapchainSubImage::new()
-//                                 .swapchain(&swapchain)
-//                                 .image_array_index(0)
-//                                 .image_rect(rect),
-//                         ),
-//                     CompositionLayerProjectionView::new()
-//                         .pose(openxr_views.0[1].pose)
-//                         .fov(openxr_views.0[1].fov)
-//                         .sub_image(
-//                             SwapchainSubImage::new()
-//                                 .swapchain(&swapchain)
-//                                 .image_array_index(1)
-//                                 .image_rect(rect),
-//                         ),
-//                 ])],
-//         )
-//         .expect("Failed to end frame");
-// }

--- a/crates/bevy_openxr/src/openxr/render.rs
+++ b/crates/bevy_openxr/src/openxr/render.rs
@@ -1,5 +1,3 @@
-use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
-
 use bevy::{
     ecs::{query::QuerySingleError, schedule::SystemConfigs},
     prelude::*,
@@ -9,7 +7,6 @@ use bevy::{
         view::ExtractedView,
         Render, RenderApp, RenderSet,
     },
-    utils::synccell::SyncCell,
 };
 use bevy_xr::camera::{XrCamera, XrCameraBundle, XrProjection};
 use openxr::ViewStateFlags;
@@ -17,7 +14,7 @@ use openxr::ViewStateFlags;
 use crate::{
     error::OxrError,
     init::{
-        session_started, OxrPreUpdateSet, OxrSessionResourceCreator, OxrSessionResourceCreators,
+        session_started, OxrPreUpdateSet, OxrSessionResourceCreator, OxrSessionResourceCreatorsApp,
         OxrTrackingRoot,
     },
     layer_builder::ProjectionLayer,
@@ -37,9 +34,7 @@ pub struct OxrRenderPlugin;
 
 impl Plugin for OxrRenderPlugin {
     fn build(&self, app: &mut App) {
-        app.world
-            .resource::<OxrSessionResourceCreators>()
-            .init_resource_creator::<OxrSwapchainCreator>();
+        app.init_xr_resource_creator::<OxrSwapchainCreator>();
         app.add_systems(
             PreUpdate,
             wait_frame
@@ -88,7 +83,7 @@ struct OxrSwapchainCreator {
 }
 
 impl OxrSessionResourceCreator for OxrSwapchainCreator {
-    fn update(&mut self, world: &mut World) -> Result<()> {
+    fn initialize(&mut self, world: &mut World) -> Result<()> {
         let instance = world.resource::<OxrInstance>();
         let system_id = **world.resource::<OxrSystemId>();
         let session_config_info = world.non_send_resource::<OxrSessionConfigInfo>();

--- a/crates/bevy_openxr/src/openxr/render.rs
+++ b/crates/bevy_openxr/src/openxr/render.rs
@@ -70,8 +70,7 @@ impl Plugin for OxrRenderPlugin {
                 )
                     .run_if(session_started),
             )
-            .insert_resource(OxrViews(vec![]))
-            .insert_resource(OxrRenderLayers(vec![Box::new(ProjectionLayer)]));
+            .insert_resource(OxrViews(vec![]));
     }
 }
 
@@ -209,6 +208,9 @@ impl OxrSessionResourceCreator for OxrSwapchainCreator {
         world.insert_resource(self.graphics_info.take().unwrap());
         world.insert_resource(self.images.take().unwrap());
         world.insert_resource(self.swapchain.take().unwrap());
+        world
+            .resource_mut::<OxrRenderLayers>()
+            .push(Box::new(ProjectionLayer));
     }
 
     fn remove_from_world(&mut self, world: &mut World) {

--- a/crates/bevy_openxr/src/openxr/resources.rs
+++ b/crates/bevy_openxr/src/openxr/resources.rs
@@ -461,7 +461,7 @@ pub struct OxrTime(pub openxr::Time);
 #[derive(ExtractResource, Resource, Clone, Copy, Default)]
 pub struct OxrRootTransform(pub GlobalTransform);
 
-#[derive(ExtractResource, Resource, Clone, Default)]
+#[derive(Resource, Clone, Default)]
 /// This is inserted into the world to signify if the session should be cleaned up.
 pub struct OxrCleanupSession(Arc<AtomicBool>);
 

--- a/crates/bevy_openxr/src/openxr/resources.rs
+++ b/crates/bevy_openxr/src/openxr/resources.rs
@@ -381,7 +381,7 @@ pub struct OxrSwapchainImages(pub Arc<Vec<wgpu::Texture>>);
 // pub struct OxrStage(pub Arc<openxr::Space>);
 
 /// Stores the latest generated [OxrViews]
-#[derive(Clone, Resource, ExtractResource, Deref, DerefMut)]
+#[derive(Clone, Resource, Deref, DerefMut)]
 pub struct OxrViews(pub Vec<openxr::View>);
 
 /// Wrapper around [openxr::SystemId] to allow it to be stored as a resource.
@@ -429,7 +429,7 @@ pub struct OxrGraphicsInfo {
 
 #[derive(Clone)]
 /// This is used to store information from startup that is needed to create the session after the instance has been created.
-pub struct SessionConfigInfo {
+pub struct OxrSessionConfigInfo {
     /// List of blend modes the openxr session can use. If [None], pick the first available blend mode.
     pub blend_modes: Option<Vec<EnvironmentBlendMode>>,
     /// List of formats the openxr session can use. If [None], pick the first available format
@@ -461,6 +461,16 @@ pub struct OxrTime(pub openxr::Time);
 #[derive(ExtractResource, Resource, Clone, Copy, Default)]
 pub struct OxrRootTransform(pub GlobalTransform);
 
-#[derive(ExtractResource, Resource, Clone, Copy, Default, Deref, DerefMut, PartialEq)]
+#[derive(ExtractResource, Resource, Clone, Default)]
 /// This is inserted into the world to signify if the session should be cleaned up.
-pub struct OxrCleanupSession(pub bool);
+pub struct OxrCleanupSession(Arc<AtomicBool>);
+
+impl OxrCleanupSession {
+    pub fn set(&self, val: bool) {
+        self.0.store(val, Ordering::SeqCst);
+    }
+
+    pub fn get(&self) -> bool {
+        self.0.load(Ordering::SeqCst)
+    }
+}

--- a/crates/bevy_xr/src/session.rs
+++ b/crates/bevy_xr/src/session.rs
@@ -118,6 +118,14 @@ pub fn session_running(status: Option<Res<XrSharedStatus>>) -> bool {
     )
 }
 
+/// A [`Condition`](bevy::ecs::schedule::Condition) system that says if the XR session is running
+pub fn session_ready_or_running(status: Option<Res<XrSharedStatus>>) -> bool {
+    matches!(
+        status.as_deref().map(XrSharedStatus::get),
+        Some(XrStatus::Running | XrStatus::Ready)
+    )
+}
+
 /// A function that returns a [`Condition`](bevy::ecs::schedule::Condition) system that says if an the [`XrStatus`] is in a specific state
 pub fn status_equals(status: XrStatus) -> impl FnMut(Option<Res<XrSharedStatus>>) -> bool {
     move |state: Option<Res<XrSharedStatus>>| state.is_some_and(|s| s.get() == status)


### PR DESCRIPTION
This implements a new way to be able to manage xr resources easily, as well as guarantee sync rules in both pipelined, and unpipelined rendering, guaranteeing that resources will go to both worlds in the same frame always, even when pipelined rendering is enabled.

1. Create a new type that implements `OxrSessionResourceCreator`. This type should have an uninitialized state. `update` is the method that will initialize the resource with `&mut World` access. SessionResourceCreators are automatically ordered so that you have access to any other session resource creators that were initialized on the app before yours. in other words, the last session resource creator added should have access to every other session resource
2. you can then use the remaining methods to control what goes into the render world, and main world. adding methods to then drop those resources also allows automatic destruction of XR objects. 
3. finally, use the `add_xr_resource_creator` or `init_xr_resource_creator` method on `App` to add the resource creator. 

code to check for implementation examples
- check `reference_space.rs` for a simple example of how this works with reference spaces.
- `session.rs` is a good decently complex example implementation with comments. 
  - line 100 for trait declaration
  - line 359 for session implementation
- lastly, see how the swapchain and graphics info are created in `render.rs`