### PR TITLE
Fix dependencies to fix compilation issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,7 +758,7 @@ dependencies = [
  "bevy",
  "bevy_mod_xr",
  "bevy_xr_utils",
- "d3d12 0.19.0",
+ "d3d12 0.20.0",
  "jni 0.20.0",
  "ndk-context",
  "openxr",

--- a/crates/bevy_openxr/Cargo.toml
+++ b/crates/bevy_openxr/Cargo.toml
@@ -42,4 +42,4 @@ wgpu = { version = "0.19.3", features = ["vulkan-portability"] }
 [target.'cfg(target_family = "windows")'.dependencies]
 openxr = { version = "0.18.0", features = ["mint", "static"] }
 winapi = { version = "0.3.9", optional = true }
-d3d12 = { version = "0.19", features = ["libloading"], optional = true }
+d3d12 = { version = "0.20", features = ["libloading"], optional = true }

--- a/crates/bevy_openxr/examples/android/Cargo.toml
+++ b/crates/bevy_openxr/examples/android/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 bevy_mod_openxr.path = "../.."
-bevy.workspace = true
+bevy = { workspace = true, default-features = true }
 bevy_xr_utils.path = "../../../bevy_xr_utils"
 
 


### PR DESCRIPTION
On windows the crates fail to compile due to a mismatch between d3d12 being pulled in by the crate itself and by wgpu. Additionally the android example did not have the default features enabled as the dependency was inherited from the workspace. Enabling these fixes materials not working in the example.