### PR TITLE
Remove default bindings

### DIFF
--- a/crates/bevy_openxr/examples/tracking_utils.rs
+++ b/crates/bevy_openxr/examples/tracking_utils.rs
@@ -1,11 +1,10 @@
 //! A simple 3D scene with light shining over a cube sitting on a plane.
 
 use bevy::prelude::*;
-use bevy_mod_openxr::add_xr_plugins;
-use bevy_mod_xr::session::{XrSessionCreated, XrTrackingRoot};
+use bevy_mod_openxr::{action_binding::OxrSendActionBindings, add_xr_plugins};
+use bevy_mod_xr::session::XrSessionCreated;
 use bevy_xr_utils::tracking_utils::{
-    TrackingUtilitiesPlugin, XrTrackedLeftGrip, XrTrackedLocalFloor, XrTrackedRightGrip,
-    XrTrackedStage, XrTrackedView,
+    suggest_action_bindings, TrackingUtilitiesPlugin, XrTrackedLeftGrip, XrTrackedLocalFloor, XrTrackedRightGrip, XrTrackedStage, XrTrackedView
 };
 
 fn main() {
@@ -18,6 +17,8 @@ fn main() {
 
     //tracking utils plugin
     app.add_plugins(TrackingUtilitiesPlugin);
+    //default bindings only use for prototyping
+    app.add_systems(OxrSendActionBindings, suggest_action_bindings);
 
     app.run();
 }

--- a/crates/bevy_xr_utils/src/tracking_utils.rs
+++ b/crates/bevy_xr_utils/src/tracking_utils.rs
@@ -201,9 +201,9 @@ fn update_right_grip(
 //tracking rig
 #[derive(Resource)]
 pub struct ControllerActions {
-    set: openxr::ActionSet,
-    left: openxr::Action<Posef>,
-    right: openxr::Action<Posef>,
+    pub set: openxr::ActionSet,
+    pub left: openxr::Action<Posef>,
+    pub right: openxr::Action<Posef>,
 }
 
 fn spawn_tracking_rig(

--- a/crates/bevy_xr_utils/src/tracking_utils.rs
+++ b/crates/bevy_xr_utils/src/tracking_utils.rs
@@ -54,7 +54,7 @@ impl Plugin for TrackingUtilitiesPlugin {
         );
 
         //bindings
-        app.add_systems(OxrSendActionBindings, suggest_action_bindings);
+        // app.add_systems(OxrSendActionBindings, suggest_action_bindings);
         //sync actions
         app.add_systems(
             PreUpdate,
@@ -200,7 +200,7 @@ fn update_right_grip(
 
 //tracking rig
 #[derive(Resource)]
-struct ControllerActions {
+pub struct ControllerActions {
     set: openxr::ActionSet,
     left: openxr::Action<Posef>,
     right: openxr::Action<Posef>,
@@ -240,7 +240,7 @@ fn spawn_tracking_rig(
 
 //bindings
 //TODO figure out how to make these better, specifically not be controller specific
-fn suggest_action_bindings(
+pub fn suggest_action_bindings(
     actions: Res<ControllerActions>,
     mut bindings: EventWriter<OxrSuggestActionBinding>,
 ) {


### PR DESCRIPTION
Made the default bindings a pub function so the end user can call it if they want. This resolves the issue while I investigate better solutions.