### PR TITLE
Update the Android example to use NativeActivity instead of GameActivity

### DIFF
--- a/crates/bevy_openxr/examples/android/Cargo.toml
+++ b/crates/bevy_openxr/examples/android/Cargo.toml
@@ -8,8 +8,15 @@ publish = false
 
 [dependencies]
 bevy_mod_openxr.workspace = true
-bevy = { workspace = true, default-features = true }
 bevy_xr_utils.workspace = true
+bevy = { workspace = true, default-features = false, features = [
+    # Bevy 0.15 made GameActivity the default which breaks Quest builds
+    # To use NativeActivity instead of GameActivity all of the features have to be listed manually
+    "android-native-activity",
+    "bevy_window",
+    "multi_threaded",
+    "tonemapping_luts",
+] }
 
 [build-dependencies]
 reqwest = { version = "0.12", features = ["blocking"] }


### PR DESCRIPTION
Bevy 0.15 changed the default `Activity` for Android projects to be `GameActivity`, which breaks Quest builds. Updated the Android example to use the `android-native-activity` feature instead of `android-game-activity`. 