### PR TITLE
Update camera texture view

### DIFF
--- a/crates/bevy_openxr/src/openxr/mod.rs
+++ b/crates/bevy_openxr/src/openxr/mod.rs
@@ -64,7 +64,7 @@ pub fn add_xr_plugins<G: PluginGroup>(plugins: G) -> PluginGroupBuilder {
         .add_before::<RenderPlugin>(OxrInitPlugin::default())
         .add(OxrEventsPlugin)
         .add(OxrReferenceSpacePlugin::default())
-        .add(OxrRenderPlugin)
+        .add(OxrRenderPlugin::default())
         .add(OxrPassthroughPlugin)
         .add(HandTrackingPlugin::default())
         .add(XrCameraPlugin)

--- a/crates/bevy_openxr/src/openxr/render.rs
+++ b/crates/bevy_openxr/src/openxr/render.rs
@@ -159,10 +159,14 @@ pub fn wait_frame(mut frame_waiter: ResMut<OxrFrameWaiter>, mut commands: Comman
 
 pub fn update_cameras(
     frame_state: Res<OxrFrameState>,
-    mut cameras: Query<&mut Camera, With<XrCamera>>,
+    mut cameras: Query<(&mut Camera, &XrCamera)>,
 ) {
+    for (mut camera, xr_camera) in &mut cameras {
+        camera.target =
+            RenderTarget::TextureView(ManualTextureViewHandle(XR_TEXTURE_INDEX + xr_camera.0));
+    }
     if frame_state.is_changed() {
-        for mut camera in &mut cameras {
+        for (mut camera, _) in &mut cameras {
             camera.is_active = frame_state.should_render
         }
     }


### PR DESCRIPTION
Sets all entities with the `XrCamera` component to use the correct render texture, allowing XrCameras to be spawned much easier. Also added an option to the `OxrRenderPlugin` to allow enabling or disabling auto spawning of cameras.