### PR TITLE
More correct wgpu init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,6 +878,7 @@ dependencies = [
 name = "bevy_mod_openxr"
 version = "0.1.1"
 dependencies = [
+ "android_system_properties",
  "ash",
  "bevy",
  "bevy_mod_xr",

--- a/crates/bevy_openxr/Cargo.toml
+++ b/crates/bevy_openxr/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["gamedev", "bevy", "Xr", "Vr", "OpenXR"]
 
 [features]
 default = ["vulkan", "d3d12", "passthrough"]
-vulkan = ["dep:ash"]
+vulkan = ["dep:ash", "dep:android_system_properties"]
 d3d12 = ["wgpu/dx12", "wgpu-hal/dx12", "dep:winapi"]
 passthrough = []
 
@@ -20,6 +20,7 @@ bevy = { workspace = true, default-features = true }
 [target.'cfg(target_os = "android")'.dependencies]
 ndk-context = "0.1"
 jni = "0.20"
+android_system_properties = { version = "0.1.5", optional = true }
 
 # bevy can't be placed behind target or proc macros won't work properly
 [dependencies]
@@ -39,7 +40,7 @@ openxr = { workspace = true, features = ["mint"] }
 wgpu = { workspace = true, features = ["vulkan-portability"] }
 
 [target.'cfg(target_family = "windows")'.dependencies]
-openxr = { workspace=true, features = ["mint", "static"] }
+openxr = { workspace = true, features = ["mint", "static"] }
 winapi = { version = "0.3.9", optional = true }
 
 [lints.clippy]


### PR DESCRIPTION
This makes the wgpu init closer to the normal init in wgpu, this should fix issues where apps made pretty reasonable assumptions about the hardware while wgpu thought that the hardware only supports the bare minimum