### PR TITLE
fix 3d_scene example on runtimes that aren't WiVRn

### DIFF
--- a/crates/bevy_openxr/examples/3d_scene.rs
+++ b/crates/bevy_openxr/examples/3d_scene.rs
@@ -12,6 +12,7 @@ fn main() {
                     blend_modes: Some(vec![
                         EnvironmentBlendMode::ALPHA_BLEND,
                         EnvironmentBlendMode::ADDITIVE,
+                        EnvironmentBlendMode::OPAQUE,
                     ]),
                     ..Default::default()
                 },


### PR DESCRIPTION
the background is black on other runtimes but i need a better EnviromentBlendMode api to fix that