### PR TITLE
Fix directional light shadows by implementing get_frustum_corners properly

### DIFF
--- a/crates/bevy_openxr/src/openxr/render.rs
+++ b/crates/bevy_openxr/src/openxr/render.rs
@@ -10,7 +10,7 @@ use bevy::{
     transform::TransformSystem,
 };
 use bevy_mod_xr::{
-    camera::{XrCamera, XrProjection, XrViewInit},
+    camera::{XrCamera, XrFov, XrProjection, XrViewInit},
     session::{
         XrFirst, XrHandleEvents, XrPreDestroySession, XrRenderSet, XrRootTransform,
         XrSessionCreated,
@@ -252,8 +252,12 @@ pub fn update_views(
             continue;
         };
 
-        let projection_matrix = calculate_projection(projection.near, view.fov);
-        projection.projection_matrix = projection_matrix;
+        projection.fov = XrFov {
+            left: view.fov.angle_left,
+            right: view.fov.angle_right,
+            down: view.fov.angle_down,
+            up: view.fov.angle_up,
+        };
 
         let openxr::Quaternionf { x, y, z, w } = view.pose.orientation;
         let rotation = Quat::from_xyzw(x, y, z, w);
@@ -282,102 +286,6 @@ pub fn update_views_render_world(
         transform.translation = translation;
         extracted_view.world_from_view = root.0.mul_transform(transform);
     }
-}
-
-fn calculate_projection(near_z: f32, fov: openxr::Fovf) -> Mat4 {
-    //  symmetric perspective for debugging
-    // let x_fov = (self.fov.angle_left.abs() + self.fov.angle_right.abs());
-    // let y_fov = (self.fov.angle_up.abs() + self.fov.angle_down.abs());
-    // return Mat4::perspective_infinite_reverse_rh(y_fov, x_fov / y_fov, self.near);
-
-    let is_vulkan_api = false; // FIXME wgpu probably abstracts this
-    let far_z = -1.; //   use infinite proj
-                     // let far_z = self.far;
-
-    let tan_angle_left = fov.angle_left.tan();
-    let tan_angle_right = fov.angle_right.tan();
-
-    let tan_angle_down = fov.angle_down.tan();
-    let tan_angle_up = fov.angle_up.tan();
-
-    let tan_angle_width = tan_angle_right - tan_angle_left;
-
-    // Set to tanAngleDown - tanAngleUp for a clip space with positive Y
-    // down (Vulkan). Set to tanAngleUp - tanAngleDown for a clip space with
-    // positive Y up (OpenGL / D3D / Metal).
-    // const float tanAngleHeight =
-    //     graphicsApi == GRAPHICS_VULKAN ? (tanAngleDown - tanAngleUp) : (tanAngleUp - tanAngleDown);
-    let tan_angle_height = if is_vulkan_api {
-        tan_angle_down - tan_angle_up
-    } else {
-        tan_angle_up - tan_angle_down
-    };
-
-    // Set to nearZ for a [-1,1] Z clip space (OpenGL / OpenGL ES).
-    // Set to zero for a [0,1] Z clip space (Vulkan / D3D / Metal).
-    // const float offsetZ =
-    //     (graphicsApi == GRAPHICS_OPENGL || graphicsApi == GRAPHICS_OPENGL_ES) ? nearZ : 0;
-    // FIXME handle enum of graphics apis
-    let offset_z = 0.;
-
-    let mut cols: [f32; 16] = [0.0; 16];
-
-    if far_z <= near_z {
-        // place the far plane at infinity
-        cols[0] = 2. / tan_angle_width;
-        cols[4] = 0.;
-        cols[8] = (tan_angle_right + tan_angle_left) / tan_angle_width;
-        cols[12] = 0.;
-
-        cols[1] = 0.;
-        cols[5] = 2. / tan_angle_height;
-        cols[9] = (tan_angle_up + tan_angle_down) / tan_angle_height;
-        cols[13] = 0.;
-
-        cols[2] = 0.;
-        cols[6] = 0.;
-        cols[10] = -1.;
-        cols[14] = -(near_z + offset_z);
-
-        cols[3] = 0.;
-        cols[7] = 0.;
-        cols[11] = -1.;
-        cols[15] = 0.;
-
-        //  bevy uses the _reverse_ infinite projection
-        //  https://dev.theomader.com/depth-precision/
-        let z_reversal = Mat4::from_cols_array_2d(&[
-            [1f32, 0., 0., 0.],
-            [0., 1., 0., 0.],
-            [0., 0., -1., 0.],
-            [0., 0., 1., 1.],
-        ]);
-
-        return z_reversal * Mat4::from_cols_array(&cols);
-    } else {
-        // normal projection
-        cols[0] = 2. / tan_angle_width;
-        cols[4] = 0.;
-        cols[8] = (tan_angle_right + tan_angle_left) / tan_angle_width;
-        cols[12] = 0.;
-
-        cols[1] = 0.;
-        cols[5] = 2. / tan_angle_height;
-        cols[9] = (tan_angle_up + tan_angle_down) / tan_angle_height;
-        cols[13] = 0.;
-
-        cols[2] = 0.;
-        cols[6] = 0.;
-        cols[10] = -(far_z + offset_z) / (far_z - near_z);
-        cols[14] = -(far_z * (near_z + offset_z)) / (far_z - near_z);
-
-        cols[3] = 0.;
-        cols[7] = 0.;
-        cols[11] = -1.;
-        cols[15] = 0.;
-    }
-
-    Mat4::from_cols_array(&cols)
 }
 
 /// # Safety

--- a/crates/bevy_xr/src/camera.rs
+++ b/crates/bevy_xr/src/camera.rs
@@ -44,7 +44,7 @@ pub struct XrViewInit;
 #[derive(Debug, Clone, Reflect, ExtractComponent)]
 #[reflect(Component, Default)]
 pub struct XrProjection {
-    pub projection_matrix: Mat4,
+    pub fov: XrFov,
     pub near: f32,
 }
 impl Component for XrProjection {
@@ -61,9 +61,17 @@ impl Default for XrProjection {
     fn default() -> Self {
         Self {
             near: 0.1,
-            projection_matrix: Mat4::IDENTITY,
+            fov: XrFov::default(),
         }
     }
+}
+
+#[derive(Default, Clone, Copy, Debug, Reflect)]
+pub struct XrFov {
+    pub left: f32,
+    pub right: f32,
+    pub up: f32,
+    pub down: f32,
 }
 
 /// Marker component for an XR view. It is the backends responsibility to update this.
@@ -75,37 +83,132 @@ impl CameraProjection for XrProjection {
     fn update(&mut self, _width: f32, _height: f32) {}
 
     fn far(&self) -> f32 {
-        self.projection_matrix.to_cols_array()[14]
-            / (self.projection_matrix.to_cols_array()[10] + 1.0)
+        let matrix = self.get_clip_from_view();
+        matrix.to_cols_array()[14] / (matrix.to_cols_array()[10] + 1.0)
     }
 
-    // TODO calculate this properly
-    fn get_frustum_corners(&self, _z_near: f32, _z_far: f32) -> [Vec3A; 8] {
-        let ndc_corners = [
-            Vec3A::new(1.0, -1.0, 1.0),   // Bottom-right far
-            Vec3A::new(1.0, 1.0, 1.0),    // Top-right far
-            Vec3A::new(-1.0, 1.0, 1.0),   // Top-left far
-            Vec3A::new(-1.0, -1.0, 1.0),  // Bottom-left far
-            Vec3A::new(1.0, -1.0, -1.0),  // Bottom-right near
-            Vec3A::new(1.0, 1.0, -1.0),   // Top-right near
-            Vec3A::new(-1.0, 1.0, -1.0),  // Top-left near
-            Vec3A::new(-1.0, -1.0, -1.0), // Bottom-left near
-        ];
+    fn get_frustum_corners(&self, z_near: f32, z_far: f32) -> [Vec3A; 8] {
+        let near = z_near.abs();
+        let far = z_far.abs();
 
-        let mut view_space_corners = [Vec3A::ZERO; 8];
-        let inverse_matrix = self.projection_matrix.inverse();
-        for (i, corner) in ndc_corners.into_iter().enumerate() {
-            view_space_corners[i] = inverse_matrix.transform_point3a(corner);
-        }
+        let tan_left = self.fov.left.tan();
+        let tan_right = self.fov.right.tan();
+        let tan_up = self.fov.up.tan();
+        let tan_down = self.fov.down.tan();
 
-        view_space_corners
+        [
+            Vec3A::new(tan_right * near, tan_down * near, z_near), // Bottom-right
+            Vec3A::new(tan_right * near, tan_up * near, z_near),   // Top-right
+            Vec3A::new(tan_left * near, tan_up * near, z_near),    // Top-left
+            Vec3A::new(tan_left * near, tan_down * near, z_near),  // Bottom-left
+            Vec3A::new(tan_right * far, tan_down * far, z_far),    // Bottom-right
+            Vec3A::new(tan_right * far, tan_up * far, z_far),      // Top-right
+            Vec3A::new(tan_left * far, tan_up * far, z_far),       // Top-left
+            Vec3A::new(tan_left * far, tan_down * far, z_far),     // Bottom-left
+        ]
     }
 
     fn get_clip_from_view(&self) -> Mat4 {
-        self.projection_matrix
+        calculate_projection(self.near, self.fov)
     }
 
     fn get_clip_from_view_for_sub(&self, _sub_view: &bevy::render::camera::SubCameraView) -> Mat4 {
         panic!("sub view not supported for xr camera");
     }
+}
+
+fn calculate_projection(near_z: f32, fov: XrFov) -> Mat4 {
+    //  symmetric perspective for debugging
+    // let x_fov = (self.fov.angle_left.abs() + self.fov.angle_right.abs());
+    // let y_fov = (self.fov.angle_up.abs() + self.fov.angle_down.abs());
+    // return Mat4::perspective_infinite_reverse_rh(y_fov, x_fov / y_fov, self.near);
+
+    let is_vulkan_api = false; // FIXME wgpu probably abstracts this
+    let far_z = -1.; //   use infinite proj
+                     // let far_z = self.far;
+
+    let tan_angle_left = fov.left.tan();
+    let tan_angle_right = fov.right.tan();
+
+    let tan_angle_down = fov.down.tan();
+    let tan_angle_up = fov.up.tan();
+
+    let tan_angle_width = tan_angle_right - tan_angle_left;
+
+    // Set to tanAngleDown - tanAngleUp for a clip space with positive Y
+    // down (Vulkan). Set to tanAngleUp - tanAngleDown for a clip space with
+    // positive Y up (OpenGL / D3D / Metal).
+    // const float tanAngleHeight =
+    //     graphicsApi == GRAPHICS_VULKAN ? (tanAngleDown - tanAngleUp) : (tanAngleUp - tanAngleDown);
+    let tan_angle_height = if is_vulkan_api {
+        tan_angle_down - tan_angle_up
+    } else {
+        tan_angle_up - tan_angle_down
+    };
+
+    // Set to nearZ for a [-1,1] Z clip space (OpenGL / OpenGL ES).
+    // Set to zero for a [0,1] Z clip space (Vulkan / D3D / Metal).
+    // const float offsetZ =
+    //     (graphicsApi == GRAPHICS_OPENGL || graphicsApi == GRAPHICS_OPENGL_ES) ? nearZ : 0;
+    // FIXME handle enum of graphics apis
+    let offset_z = 0.;
+
+    let mut cols: [f32; 16] = [0.0; 16];
+
+    if far_z <= near_z {
+        // place the far plane at infinity
+        cols[0] = 2. / tan_angle_width;
+        cols[4] = 0.;
+        cols[8] = (tan_angle_right + tan_angle_left) / tan_angle_width;
+        cols[12] = 0.;
+
+        cols[1] = 0.;
+        cols[5] = 2. / tan_angle_height;
+        cols[9] = (tan_angle_up + tan_angle_down) / tan_angle_height;
+        cols[13] = 0.;
+
+        cols[2] = 0.;
+        cols[6] = 0.;
+        cols[10] = -1.;
+        cols[14] = -(near_z + offset_z);
+
+        cols[3] = 0.;
+        cols[7] = 0.;
+        cols[11] = -1.;
+        cols[15] = 0.;
+
+        //  bevy uses the _reverse_ infinite projection
+        //  https://dev.theomader.com/depth-precision/
+        let z_reversal = Mat4::from_cols_array_2d(&[
+            [1f32, 0., 0., 0.],
+            [0., 1., 0., 0.],
+            [0., 0., -1., 0.],
+            [0., 0., 1., 1.],
+        ]);
+
+        return z_reversal * Mat4::from_cols_array(&cols);
+    } else {
+        // normal projection
+        cols[0] = 2. / tan_angle_width;
+        cols[4] = 0.;
+        cols[8] = (tan_angle_right + tan_angle_left) / tan_angle_width;
+        cols[12] = 0.;
+
+        cols[1] = 0.;
+        cols[5] = 2. / tan_angle_height;
+        cols[9] = (tan_angle_up + tan_angle_down) / tan_angle_height;
+        cols[13] = 0.;
+
+        cols[2] = 0.;
+        cols[6] = 0.;
+        cols[10] = -(far_z + offset_z) / (far_z - near_z);
+        cols[14] = -(far_z * (near_z + offset_z)) / (far_z - near_z);
+
+        cols[3] = 0.;
+        cols[7] = 0.;
+        cols[11] = -1.;
+        cols[15] = 0.;
+    }
+
+    Mat4::from_cols_array(&cols)
 }


### PR DESCRIPTION
`XrProjection` now stores the FOV parameters instead of the full projection matrix. Calculation of the projection matrix has been moved to camera.rs

Fixes #179