### PR TITLE
revert alpha "fix"

### DIFF
--- a/crates/bevy_openxr/examples/overlay.rs
+++ b/crates/bevy_openxr/examples/overlay.rs
@@ -2,11 +2,8 @@
 
 use bevy::prelude::*;
 use bevy_mod_openxr::{
-    add_xr_plugins,
-    features::overlay::{OxrOverlaySessionEvent, OxrOverlaySettings},
-    init::OxrInitPlugin,
-    resources::OxrSessionConfig,
-    types::OxrExtensions,
+    add_xr_plugins, features::overlay::OxrOverlaySessionEvent, init::OxrInitPlugin,
+    resources::OxrSessionConfig, types::OxrExtensions,
 };
 use openxr::EnvironmentBlendMode;
 
@@ -21,10 +18,6 @@ fn main() {
             },
             ..OxrInitPlugin::default()
         }))
-        .insert_resource(OxrOverlaySettings {
-            session_layer_placement: 300,
-            ..Default::default()
-        })
         .insert_resource(OxrSessionConfig {
             blend_mode_preference: {
                 vec![
@@ -89,11 +82,7 @@ fn setup(
     // cube
     commands.spawn((
         Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
-        MeshMaterial3d(materials.add(StandardMaterial {
-            base_color: Color::srgba_u8(124, 144, 255, 127),
-            alpha_mode: AlphaMode::Blend,
-            ..Default::default()
-        })),
+        MeshMaterial3d(materials.add(Color::srgb_u8(124, 144, 255))),
         Transform::from_xyz(0.0, 2.5, 0.0),
     ));
     // light

--- a/crates/bevy_openxr/src/openxr/layer_builder.rs
+++ b/crates/bevy_openxr/src/openxr/layer_builder.rs
@@ -36,10 +36,7 @@ impl LayerProvider for ProjectionLayer {
 
         Some(Box::new(
             CompositionLayerProjection::new()
-                .layer_flags(
-                    CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA
-                        | CompositionLayerFlags::UNPREMULTIPLIED_ALPHA,
-                )
+                .layer_flags(CompositionLayerFlags::BLEND_TEXTURE_SOURCE_ALPHA)
                 .space(stage)
                 .views(&[
                     CompositionLayerProjectionView::new()
@@ -174,7 +171,7 @@ impl Default for CompositionLayerProjectionView<'_> {
     }
 }
 /// # Safety
-/// the header function must return a ref to a valid Composition Layer struct.
+/// the header function must return a ref to a valid Composition Layer struct. 
 /// it has to use `repr(C)` and it has to follow the shape of a Composition Layer struct from the
 /// OpenXR specification
 pub unsafe trait CompositionLayer<'a> {


### PR DESCRIPTION
alpha compositing in the runtime might still look wrong, it seems to be related to tonemapping somehow? so try disabling that if you hit that issue