### PR TITLE
Add opt-in OpenXR foveation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ checksum = "bff34eb29ff4b8a8688bc7299f14fb6b597461ca80fec03ed7d22939ab33e48f"
 
 [[package]]
 name = "bevy_mod_openxr"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "android-activity",
  "android_system_properties",
@@ -1206,6 +1206,7 @@ dependencies = [
  "bevy_window",
  "bevy_winit",
  "jni 0.20.0",
+ "libc",
  "ndk-context",
  "openxr",
  "thiserror 2.0.18",
@@ -1226,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_mod_xr"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bevy_app",
  "bevy_camera",
@@ -1243,7 +1244,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_openxr_android"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bevy",
  "bevy_mod_openxr",
@@ -1885,7 +1886,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_xr_utils"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bevy",
  "bevy_app",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ checksum = "bff34eb29ff4b8a8688bc7299f14fb6b597461ca80fec03ed7d22939ab33e48f"
 
 [[package]]
 name = "bevy_mod_openxr"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "android-activity",
  "android_system_properties",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_mod_xr"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bevy_app",
  "bevy_camera",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_openxr_android"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bevy",
  "bevy_mod_openxr",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_xr_utils"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bevy",
  "bevy_app",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ bevy_derive = { version = "0.19", default-features = false }
 bevy_platform = { version = "0.19", default-features = false }
 
 
-bevy_mod_xr = { path = "crates/bevy_xr", version = "0.5.0" }
-bevy_mod_openxr = { path = "crates/bevy_openxr", version = "0.5.0" }
-bevy_xr_utils = { path = "crates/bevy_xr_utils", version = "0.5.0" }
+bevy_mod_xr = { path = "crates/bevy_xr", version = "0.6.0" }
+bevy_mod_openxr = { path = "crates/bevy_openxr", version = "0.6.0" }
+bevy_xr_utils = { path = "crates/bevy_xr_utils", version = "0.6.0" }
 openxr = "0.21.1"
 thiserror = "2.0.3"
 wgpu = "29"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A crate for adding openxr (and in the future webxr) support to Bevy.
 
 To see it in action run the example in `crates/bevy_openxr/examples` with `cargo run -p bevy_mod_openxr --example 3d_scene`
 
+The OpenXR backend can also expose an opt-in stereo multiview swapchain view for custom render graph nodes. See `cargo run -p bevy_mod_openxr --example multiview` and the `bevy_mod_openxr` README for details.
+
 ## Discord
 
 Come hang out if you have questions or issues 
@@ -33,4 +35,3 @@ at your option. This means you can select the license you prefer!
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall
 be dual licensed as above, without any additional terms or conditions.
-

--- a/crates/bevy_openxr/Cargo.toml
+++ b/crates/bevy_openxr/Cargo.toml
@@ -24,6 +24,7 @@ jni = "0.20"
 android_system_properties = { version = "0.1.5", optional = true }
 # android-activity 0.6.1 changed how the global android context is initialized, requiring some changes in the upstream openxr bindings.
 android-activity = "=0.6.0"
+libc = "0.2"
 
 # bevy can't be placed behind target or proc macros won't work properly
 [dependencies]

--- a/crates/bevy_openxr/README.md
+++ b/crates/bevy_openxr/README.md
@@ -29,5 +29,36 @@ This does not automatically convert Bevy's built-in PBR or core render passes to
 
 See `cargo run -p bevy_mod_openxr --example multiview` for a minimal setup example.
 
+## Fixed foveated rendering
+
+Applications can opt into the `XR_FB_foveation` extension family by adding
+`OxrFoveationPlugin` before the OpenXR plugins are initialized:
+
+```rust
+use bevy::prelude::*;
+use bevy_mod_openxr::{
+    add_xr_plugins,
+    foveation::{OxrFoveationConfig, OxrFoveationPlugin},
+};
+
+fn main() {
+    App::new()
+        .add_plugins(OxrFoveationPlugin::new(
+            OxrFoveationConfig::medium().dynamic(true),
+        ))
+        .add_plugins(add_xr_plugins(DefaultPlugins))
+        .run();
+}
+```
+
+On Vulkan, this requests the OpenXR foveation extensions, enables the Vulkan
+fragment-density-map device extensions, creates the swapchain with foveation
+enabled, and applies a foveation profile. Runtimes that do not expose every
+required extension automatically fall back to a regular swapchain.
+
+Current `wgpu` render pass APIs do not expose a fragment density map attachment,
+so applications should validate visual quality and performance on target
+headsets before relying on a GPU time reduction.
+
 ![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2FlOXJrOG1pbzFkYTVjZHIybndqamF1a2YwZHU3dXgyZGcwdmFzMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/CHbQyXOT5yZZ1VQRh7/giphy-downsized-large.gif)
 ![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHVmZXc2b3VhcGE2eHE2c2Y3NDR6cXNibHdjNjk5MmtyOHlkMXkwZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Hsvp5el2o7tzgOf9GQ/giphy-downsized-large.gif)

--- a/crates/bevy_openxr/README.md
+++ b/crates/bevy_openxr/README.md
@@ -2,5 +2,32 @@
 
 This is the OpenXR backend for bevy_mod_xr for more info see the [repo](https://github.com/awtterpip/bevy_oxr)
 
+## Stereo multiview
+
+The default stereo path renders each eye through its own 2D texture view. This is the most compatible mode and is what Bevy's built-in 3D render graph expects today.
+
+Apps that provide their own multiview-aware render graph nodes can ask the OpenXR backend to also expose a 2-layer array texture view for the current stereo swapchain image:
+
+```rust
+use bevy::prelude::*;
+use bevy_mod_openxr::add_xr_plugins;
+use bevy_mod_xr::camera::XrStereoRenderMode;
+
+fn main() {
+    App::new()
+        .insert_resource(XrStereoRenderMode::stereo_multiview())
+        .add_plugins(add_xr_plugins(DefaultPlugins))
+        .run();
+}
+```
+
+The multiview texture view is available from `bevy_mod_openxr::render::xr_multiview_texture_view_handle()`. Custom render passes should use that manual texture view and set `wgpu::RenderPassDescriptor::multiview_mask` to `XrStereoRenderMode::view_mask()`.
+
+The render device must support `wgpu::Features::MULTIVIEW` before a custom pass uses a non-empty multiview mask.
+
+This does not automatically convert Bevy's built-in PBR or core render passes to single-pass stereo. Those passes still need multiview-aware render graph integration and shaders that select per-eye data with the platform view index.
+
+See `cargo run -p bevy_mod_openxr --example multiview` for a minimal setup example.
+
 ![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2FlOXJrOG1pbzFkYTVjZHIybndqamF1a2YwZHU3dXgyZGcwdmFzMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/CHbQyXOT5yZZ1VQRh7/giphy-downsized-large.gif)
 ![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHVmZXc2b3VhcGE2eHE2c2Y3NDR6cXNibHdjNjk5MmtyOHlkMXkwZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Hsvp5el2o7tzgOf9GQ/giphy-downsized-large.gif)

--- a/crates/bevy_openxr/examples/multiview.rs
+++ b/crates/bevy_openxr/examples/multiview.rs
@@ -1,0 +1,57 @@
+//! Requests OpenXR stereo multiview resources.
+//!
+//! Bevy's built-in 3D render graph still renders through the per-eye texture views. Custom render
+//! graph nodes can target `xr_multiview_texture_view_handle()` and set the render pass
+//! `multiview_mask` to the configured `XrStereoRenderMode::view_mask()`.
+
+use bevy::{prelude::*, render::pipelined_rendering::PipelinedRenderingPlugin};
+use bevy_mod_openxr::{
+    add_xr_plugins,
+    render::{xr_multiview_texture_view_handle, XR_MULTIVIEW_TEXTURE_INDEX},
+};
+use bevy_mod_xr::camera::XrStereoRenderMode;
+
+fn main() -> AppExit {
+    App::new()
+        .insert_resource(XrStereoRenderMode::stereo_multiview())
+        .add_plugins(add_xr_plugins(
+            DefaultPlugins.build().disable::<PipelinedRenderingPlugin>(),
+        ))
+        .add_systems(Startup, (log_multiview_target, setup))
+        .run()
+}
+
+fn log_multiview_target(stereo_render_mode: Res<XrStereoRenderMode>) {
+    let _handle = xr_multiview_texture_view_handle();
+    info!(
+        "OpenXR stereo multiview target requested at manual texture view index {}; pass mask: {:?}",
+        XR_MULTIVIEW_TEXTURE_INDEX,
+        stereo_render_mode.view_mask()
+    );
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn((
+        Mesh3d(meshes.add(Circle::new(4.0))),
+        MeshMaterial3d(materials.add(Color::WHITE)),
+        Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
+    ));
+
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb_u8(124, 144, 255))),
+        Transform::from_xyz(0.0, 0.5, 0.0),
+    ));
+
+    commands.spawn((
+        PointLight {
+            shadow_maps_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+}

--- a/crates/bevy_openxr/src/openxr/android_thread_settings.rs
+++ b/crates/bevy_openxr/src/openxr/android_thread_settings.rs
@@ -1,0 +1,100 @@
+use crate::resources::OxrInstance;
+use crate::session::OxrSession;
+use bevy_ecs::resource::Resource;
+use bevy_ecs::system::{Res, ResMut};
+use bevy_log::{error, info, warn};
+
+/// The OS thread ID (Linux `gettid()`) of the application's main thread.
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct MainThreadTid(pub u32);
+
+/// Tracks render-world thread tagging so it is attempted once per render thread.
+#[derive(Resource, Debug, Default)]
+pub struct AndroidThreadTagState {
+    renderer_main_tid: Option<u32>,
+    renderer_main_failed_tid: Option<u32>,
+    extension_unavailable_logged: bool,
+}
+
+pub fn current_thread_tid() -> u32 {
+    unsafe { libc::gettid() as u32 }
+}
+
+pub fn tag_application_main_thread(instance: &OxrInstance, session: &OxrSession, tid: u32) {
+    match tag_thread(
+        instance,
+        session,
+        openxr::sys::AndroidThreadTypeKHR::APPLICATION_MAIN,
+        tid,
+    ) {
+        ThreadTagStatus::Tagged => {
+            info!("XR thread tagging: APPLICATION_MAIN tagged (tid={tid})");
+        }
+        ThreadTagStatus::ExtensionUnavailable => {
+            warn!("XR thread tagging: XR_KHR_android_thread_settings unavailable; skipping");
+        }
+        ThreadTagStatus::Failed(result) => {
+            warn!("XR thread tagging: APPLICATION_MAIN failed for tid={tid}: {result:?}");
+        }
+    }
+}
+
+pub fn tag_render_thread_system(
+    instance: Res<OxrInstance>,
+    session: Res<OxrSession>,
+    mut state: ResMut<AndroidThreadTagState>,
+) {
+    let tid = current_thread_tid();
+    if state.renderer_main_tid == Some(tid) || state.renderer_main_failed_tid == Some(tid) {
+        return;
+    }
+
+    match tag_thread(
+        &instance,
+        &session,
+        openxr::sys::AndroidThreadTypeKHR::RENDERER_MAIN,
+        tid,
+    ) {
+        ThreadTagStatus::Tagged => {
+            state.renderer_main_tid = Some(tid);
+            state.renderer_main_failed_tid = None;
+            info!("XR thread tagging: RENDERER_MAIN tagged (tid={tid})");
+        }
+        ThreadTagStatus::ExtensionUnavailable => {
+            if !state.extension_unavailable_logged {
+                state.extension_unavailable_logged = true;
+                warn!("XR thread tagging: XR_KHR_android_thread_settings unavailable; skipping");
+            }
+        }
+        ThreadTagStatus::Failed(result) => {
+            state.renderer_main_failed_tid = Some(tid);
+            warn!("XR thread tagging: RENDERER_MAIN failed for tid={tid}: {result:?}");
+        }
+    }
+}
+
+enum ThreadTagStatus {
+    Tagged,
+    ExtensionUnavailable,
+    Failed(openxr::sys::Result),
+}
+
+fn tag_thread(
+    instance: &OxrInstance,
+    session: &OxrSession,
+    thread_type: openxr::sys::AndroidThreadTypeKHR,
+    tid: u32,
+) -> ThreadTagStatus {
+    let Some(khr) = instance.exts().khr_android_thread_settings.as_ref() else {
+        return ThreadTagStatus::ExtensionUnavailable;
+    };
+
+    let result =
+        unsafe { (khr.set_android_application_thread)(session.as_raw(), thread_type, tid) };
+    if result == openxr::sys::Result::SUCCESS {
+        ThreadTagStatus::Tagged
+    } else {
+        error!("XR thread tagging call failed for {thread_type:?}, tid={tid}: {result:?}");
+        ThreadTagStatus::Failed(result)
+    }
+}

--- a/crates/bevy_openxr/src/openxr/exts.rs
+++ b/crates/bevy_openxr/src/openxr/exts.rs
@@ -40,6 +40,14 @@ impl OxrExtensions {
         self.0.extx_overlay = true;
         self
     }
+    pub fn enable_fb_foveation(&mut self) -> &mut Self {
+        self.0.fb_swapchain_update_state = true;
+        self.0.fb_foveation = true;
+        self.0.fb_foveation_configuration = true;
+        self.0.fb_foveation_vulkan = true;
+        self.0.meta_vulkan_swapchain_create_info = true;
+        self
+    }
     /// returns true if all of the extensions enabled are also available in `available_exts`
     pub fn is_available(&self, available_exts: &OxrExtensions) -> bool {
         self.0.intersection(&available_exts) == self.0

--- a/crates/bevy_openxr/src/openxr/foveation.rs
+++ b/crates/bevy_openxr/src/openxr/foveation.rs
@@ -1,0 +1,105 @@
+use bevy_app::{App, Plugin};
+use bevy_ecs::resource::Resource;
+use openxr::{FoveationDynamicFB, FoveationLevelFB};
+
+use crate::exts::OxrExtensions;
+
+/// Fixed foveated rendering settings for OpenXR runtimes that expose the
+/// `XR_FB_foveation` extension family.
+///
+/// Insert this resource before [`OxrInitPlugin`](crate::init::OxrInitPlugin)
+/// is built so the OpenXR instance and graphics device can request the
+/// required extensions.
+#[derive(Clone, Copy, Debug, PartialEq, Resource)]
+pub struct OxrFoveationConfig {
+    pub level: FoveationLevelFB,
+    pub dynamic: FoveationDynamicFB,
+    pub vertical_offset: f32,
+    pub use_fragment_density_map: bool,
+    pub use_subsampled_layout: bool,
+}
+
+impl OxrFoveationConfig {
+    pub const fn new(level: FoveationLevelFB) -> Self {
+        Self {
+            level,
+            dynamic: FoveationDynamicFB::DISABLED,
+            vertical_offset: 0.0,
+            use_fragment_density_map: true,
+            use_subsampled_layout: true,
+        }
+    }
+
+    pub const fn low() -> Self {
+        Self::new(FoveationLevelFB::LOW)
+    }
+
+    pub const fn medium() -> Self {
+        Self::new(FoveationLevelFB::MEDIUM)
+    }
+
+    pub const fn high() -> Self {
+        Self::new(FoveationLevelFB::HIGH)
+    }
+
+    pub const fn dynamic(mut self, dynamic: bool) -> Self {
+        self.dynamic = if dynamic {
+            FoveationDynamicFB::LEVEL_ENABLED
+        } else {
+            FoveationDynamicFB::DISABLED
+        };
+        self
+    }
+
+    pub const fn vertical_offset(mut self, vertical_offset: f32) -> Self {
+        self.vertical_offset = vertical_offset;
+        self
+    }
+
+    pub const fn without_subsampled_layout(mut self) -> Self {
+        self.use_subsampled_layout = false;
+        self
+    }
+
+    pub(crate) fn required_extensions(self) -> OxrExtensions {
+        let mut exts = OxrExtensions::default();
+        exts.raw_mut().fb_swapchain_update_state = true;
+        exts.raw_mut().fb_foveation = true;
+        exts.raw_mut().fb_foveation_configuration = true;
+        if self.use_fragment_density_map {
+            exts.raw_mut().fb_foveation_vulkan = true;
+        }
+        if self.use_subsampled_layout {
+            exts.raw_mut().meta_vulkan_swapchain_create_info = true;
+        }
+        exts
+    }
+}
+
+impl Default for OxrFoveationConfig {
+    fn default() -> Self {
+        Self::medium()
+    }
+}
+
+pub struct OxrFoveationPlugin {
+    pub config: OxrFoveationConfig,
+}
+
+impl OxrFoveationPlugin {
+    pub const fn new(config: OxrFoveationConfig) -> Self {
+        Self { config }
+    }
+}
+
+impl Plugin for OxrFoveationPlugin {
+    fn build(&self, app: &mut App) {
+        app.insert_resource(self.config);
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Resource)]
+pub(crate) struct OxrEnabledFoveationConfig(pub OxrFoveationConfig);
+
+#[derive(Clone, Resource)]
+pub struct OxrFoveationProfile(pub openxr::FoveationProfileFB);

--- a/crates/bevy_openxr/src/openxr/graphics.rs
+++ b/crates/bevy_openxr/src/openxr/graphics.rs
@@ -54,7 +54,7 @@ pub unsafe trait GraphicsExt: openxr::Graphics {
     ) -> Result<WgpuGraphics>;
 }
 
-#[derive(Resource)]
+#[derive(Resource, Clone)]
 pub struct OxrManualGraphicsConfig {
     pub fallback_backend: GraphicsBackend,
     pub vk_instance_exts: Vec<&'static CStr>,

--- a/crates/bevy_openxr/src/openxr/init.rs
+++ b/crates/bevy_openxr/src/openxr/init.rs
@@ -84,6 +84,10 @@ pub struct OxrInitPlugin {
     pub synchronous_pipeline_compilation: bool,
     pub render_debug_flags: RenderDebugFlags,
 }
+
+#[derive(Clone, Copy, Debug, Resource)]
+pub struct OxrDisplayRefreshRateRequest(pub f32);
+
 impl Default for OxrInitPlugin {
     fn default() -> Self {
         Self {
@@ -400,6 +404,8 @@ fn init_xr_session(
         resolutions,
     }: OxrSessionConfig,
     graphics_info: SessionGraphicsCreateInfo,
+    display_refresh_rate_request: Option<f32>,
+    display_refresh_rate_enabled: bool,
 ) -> OxrResult<(
     OxrSession,
     OxrFrameWaiter,
@@ -411,6 +417,39 @@ fn init_xr_session(
 )> {
     let (session, frame_waiter, frame_stream) =
         unsafe { instance.create_session(system_id, graphics_info, chain)? };
+
+    if let Some(requested_hz) = display_refresh_rate_request {
+        if display_refresh_rate_enabled {
+            match session.enumerate_display_refresh_rates() {
+                Ok(rates) => info!(
+                    "OpenXR display refresh available_rates={rates:?} requested_hz={requested_hz:.3}"
+                ),
+                Err(err) => warn!(
+                    "OpenXR display refresh enumerate failed requested_hz={requested_hz:.3} error={err}"
+                ),
+            }
+            match session.get_display_refresh_rate() {
+                Ok(current_hz) => info!(
+                    "OpenXR display refresh before_request current_hz={current_hz:.3} requested_hz={requested_hz:.3}"
+                ),
+                Err(err) => warn!(
+                    "OpenXR display refresh get before request failed requested_hz={requested_hz:.3} error={err}"
+                ),
+            }
+            match session.request_display_refresh_rate(requested_hz) {
+                Ok(()) => {
+                    info!("OpenXR display refresh request submitted requested_hz={requested_hz:.3}")
+                }
+                Err(err) => warn!(
+                    "OpenXR display refresh request failed requested_hz={requested_hz:.3} error={err}"
+                ),
+            }
+        } else {
+            warn!(
+                "OpenXR display refresh request skipped; XR_FB_display_refresh_rate unavailable requested_hz={requested_hz:.3}"
+            );
+        }
+    }
 
     // TODO!() support other view configurations
     let available_view_configurations = instance.enumerate_view_configurations(system_id)?;
@@ -520,6 +559,13 @@ pub fn create_xr_session(world: &mut World) {
     let session_config = world.resource::<OxrSessionConfig>();
     let session_create_info = world.non_send::<SessionGraphicsCreateInfo>();
     let system_id = world.resource::<OxrSystemId>();
+    let display_refresh_rate_request = world
+        .get_resource::<OxrDisplayRefreshRateRequest>()
+        .map(|request| request.0);
+    let display_refresh_rate_enabled = world
+        .resource::<OxrEnabledExtensions>()
+        .raw()
+        .fb_display_refresh_rate;
     match init_xr_session(
         device.wgpu_device(),
         &instance,
@@ -527,6 +573,8 @@ pub fn create_xr_session(world: &mut World) {
         &mut chain,
         session_config.clone(),
         session_create_info.clone(),
+        display_refresh_rate_request,
+        display_refresh_rate_enabled,
     ) {
         Ok((
             session,

--- a/crates/bevy_openxr/src/openxr/init.rs
+++ b/crates/bevy_openxr/src/openxr/init.rs
@@ -49,6 +49,8 @@ use crate::session::OxrSessionCreateNextChain;
 use crate::types::Result as OxrResult;
 use crate::types::*;
 
+#[cfg(target_os = "android")]
+use super::android_thread_settings::{self, AndroidThreadTagState, MainThreadTid};
 use super::environment_blend_mode::OxrEnvironmentBlendModes;
 use super::exts::OxrEnabledExtensions;
 use super::poll_events::OxrEventHandlerExt;
@@ -101,6 +103,9 @@ impl Default for OxrInitPlugin {
 impl Plugin for OxrInitPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<OxrSessionConfig>();
+        #[cfg(target_os = "android")]
+        app.insert_resource(MainThreadTid(android_thread_settings::current_thread_tid()));
+
         let cfg = app.world_mut().remove_resource::<OxrManualGraphicsConfig>();
         match self.init_xr(cfg.as_ref()) {
             Ok((
@@ -182,6 +187,16 @@ impl Plugin for OxrInitPlugin {
                     .insert_resource(system_id)
                     .insert_resource(XrState::Available)
                     .insert_resource(OxrSessionStarted(false));
+
+                #[cfg(target_os = "android")]
+                render_app
+                    .init_resource::<AndroidThreadTagState>()
+                    .add_systems(
+                        Render,
+                        android_thread_settings::tag_render_thread_system
+                            .in_set(XrRenderSystems::HandleEvents)
+                            .run_if(resource_exists::<OxrSession>),
+                    );
             }
             Err(e) => {
                 error!("Failed to initialize openxr: {e}");
@@ -269,9 +284,17 @@ impl OxrInitPlugin {
         entry.initialize_android_loader()?;
 
         let available_exts = entry.enumerate_extensions()?;
+        #[cfg(target_os = "android")]
+        let requested_exts = {
+            let mut requested_exts = self.exts.clone();
+            requested_exts.raw_mut().khr_android_thread_settings = true;
+            requested_exts
+        };
+        #[cfg(not(target_os = "android"))]
+        let requested_exts = self.exts.clone();
 
         // check available extensions and send a warning for any wanted extensions that aren't available.
-        for ext in available_exts.unavailable_exts(&self.exts) {
+        for ext in available_exts.unavailable_exts(&requested_exts) {
             warn!(
                 "Extension \"{ext}\" not available in the current OpenXR runtime. Disabling extension."
             );
@@ -294,7 +317,7 @@ impl OxrInitPlugin {
         }
         .ok_or(OxrError::NoAvailableBackend)?;
 
-        let exts = self.exts.clone() & available_exts;
+        let exts = requested_exts & available_exts;
 
         let instance = entry.create_instance(self.app_info.clone(), exts.clone(), &[], backend)?;
         let instance_props = instance.properties()?;
@@ -493,13 +516,13 @@ pub fn create_xr_session(world: &mut World) {
         .remove_non_send::<OxrSessionCreateNextChain>()
         .unwrap();
     let device = world.resource::<RenderDevice>();
-    let instance = world.resource::<OxrInstance>();
+    let instance = world.resource::<OxrInstance>().clone();
     let session_config = world.resource::<OxrSessionConfig>();
     let session_create_info = world.non_send::<SessionGraphicsCreateInfo>();
     let system_id = world.resource::<OxrSystemId>();
     match init_xr_session(
         device.wgpu_device(),
-        instance,
+        &instance,
         **system_id,
         &mut chain,
         session_config.clone(),
@@ -515,6 +538,14 @@ pub fn create_xr_session(world: &mut World) {
             blend_modes,
         )) => {
             world.insert_resource(session.clone());
+            #[cfg(target_os = "android")]
+            {
+                let main_tid = world
+                    .get_resource::<MainThreadTid>()
+                    .map(|t| t.0)
+                    .unwrap_or_else(android_thread_settings::current_thread_tid);
+                android_thread_settings::tag_application_main_thread(&instance, &session, main_tid);
+            }
             world.insert_resource(frame_waiter);
             world.insert_resource(images);
             world.insert_resource(graphics_info);

--- a/crates/bevy_openxr/src/openxr/init.rs
+++ b/crates/bevy_openxr/src/openxr/init.rs
@@ -42,6 +42,9 @@ use bevy_winit::UpdateMode;
 use bevy_winit::WinitSettings;
 
 use crate::error::OxrError;
+use crate::foveation::OxrEnabledFoveationConfig;
+use crate::foveation::OxrFoveationConfig;
+use crate::foveation::OxrFoveationProfile;
 use crate::graphics::*;
 use crate::resources::*;
 use crate::session::OxrSession;
@@ -111,13 +114,15 @@ impl Plugin for OxrInitPlugin {
         app.insert_resource(MainThreadTid(android_thread_settings::current_thread_tid()));
 
         let cfg = app.world_mut().remove_resource::<OxrManualGraphicsConfig>();
-        match self.init_xr(cfg.as_ref()) {
+        let foveation = app.world().get_resource::<OxrFoveationConfig>().copied();
+        match self.init_xr(cfg.clone(), foveation) {
             Ok((
                 instance,
                 system_id,
                 WgpuGraphics(device, queue, adapter_info, adapter, wgpu_instance),
                 enabled_exts,
                 graphics_info,
+                enabled_foveation,
             )) => {
                 app.insert_resource(enabled_exts)
                     .add_plugins((
@@ -171,6 +176,9 @@ impl Plugin for OxrInitPlugin {
                     .insert_resource(OxrSessionStarted(false))
                     .insert_non_send(graphics_info)
                     .init_non_send::<OxrSessionCreateNextChain>();
+                if let Some(foveation) = enabled_foveation {
+                    app.insert_resource(OxrEnabledFoveationConfig(foveation));
+                }
                 #[cfg(feature = "window_support")]
                 {
                     app.insert_resource(WinitSettings {
@@ -271,13 +279,15 @@ fn detect_session_destroyed(
 impl OxrInitPlugin {
     fn init_xr(
         &self,
-        cfg: Option<&OxrManualGraphicsConfig>,
+        mut cfg: Option<OxrManualGraphicsConfig>,
+        foveation: Option<OxrFoveationConfig>,
     ) -> OxrResult<(
         OxrInstance,
         OxrSystemId,
         WgpuGraphics,
         OxrEnabledExtensions,
         SessionGraphicsCreateInfo,
+        Option<OxrFoveationConfig>,
     )> {
         #[cfg(windows)]
         let entry = OxrEntry(openxr::Entry::linked());
@@ -289,13 +299,17 @@ impl OxrInitPlugin {
 
         let available_exts = entry.enumerate_extensions()?;
         #[cfg(target_os = "android")]
-        let requested_exts = {
+        let mut requested_exts = {
             let mut requested_exts = self.exts.clone();
             requested_exts.raw_mut().khr_android_thread_settings = true;
             requested_exts
         };
         #[cfg(not(target_os = "android"))]
-        let requested_exts = self.exts.clone();
+        let mut requested_exts = self.exts.clone();
+
+        if let Some(config) = foveation {
+            requested_exts = requested_exts | config.required_extensions();
+        }
 
         // check available extensions and send a warning for any wanted extensions that aren't available.
         for ext in available_exts.unavailable_exts(&requested_exts) {
@@ -322,6 +336,13 @@ impl OxrInitPlugin {
         .ok_or(OxrError::NoAvailableBackend)?;
 
         let exts = requested_exts & available_exts;
+        let foveation = foveation.filter(|config| {
+            let is_available = config.required_extensions().is_available(&exts);
+            if !is_available {
+                warn!("OpenXR foveation disabled because one or more required extensions are not available");
+            }
+            is_available
+        });
 
         let instance = entry.create_instance(self.app_info.clone(), exts.clone(), &[], backend)?;
         let instance_props = instance.properties()?;
@@ -343,7 +364,13 @@ impl OxrInitPlugin {
             }
         );
 
-        let (graphics, graphics_info) = instance.init_graphics(system_id, cfg)?;
+        if let Some(config) = foveation
+            && config.use_fragment_density_map
+        {
+            add_vulkan_foveation_device_extensions(&mut cfg);
+        }
+
+        let (graphics, graphics_info) = instance.init_graphics(system_id, cfg.as_ref())?;
 
         Ok((
             instance,
@@ -351,8 +378,27 @@ impl OxrInitPlugin {
             graphics,
             OxrEnabledExtensions(exts),
             graphics_info,
+            foveation,
         ))
     }
+}
+
+#[cfg(feature = "vulkan")]
+fn add_vulkan_foveation_device_extensions(cfg: &mut Option<OxrManualGraphicsConfig>) {
+    let cfg = cfg.get_or_insert_with(|| OxrManualGraphicsConfig {
+        fallback_backend: GraphicsBackend::Vulkan(()),
+        vk_instance_exts: Vec::new(),
+        vk_device_exts: Vec::new(),
+    });
+    cfg.vk_device_exts
+        .push(ash::ext::fragment_density_map::NAME);
+    cfg.vk_device_exts
+        .push(ash::ext::fragment_density_map2::NAME);
+}
+
+#[cfg(not(feature = "vulkan"))]
+fn add_vulkan_foveation_device_extensions(_cfg: &mut Option<OxrManualGraphicsConfig>) {
+    warn!("OpenXR foveation requested, but Vulkan support is not enabled");
 }
 
 pub fn handle_events(
@@ -406,6 +452,7 @@ fn init_xr_session(
     graphics_info: SessionGraphicsCreateInfo,
     display_refresh_rate_request: Option<f32>,
     display_refresh_rate_enabled: bool,
+    foveation: Option<OxrFoveationConfig>,
 ) -> OxrResult<(
     OxrSession,
     OxrFrameWaiter,
@@ -414,6 +461,7 @@ fn init_xr_session(
     OxrSwapchainImages,
     OxrCurrentSessionConfig,
     OxrEnvironmentBlendModes,
+    Option<OxrFoveationProfile>,
 )> {
     let (session, frame_waiter, frame_stream) =
         unsafe { instance.create_session(system_id, graphics_info, chain)? };
@@ -515,7 +563,7 @@ fn init_xr_session(
     }
     .ok_or(OxrError::NoAvailableFormat)?;
 
-    let swapchain = session.create_swapchain(SwapchainCreateInfo {
+    let swapchain_create_info = SwapchainCreateInfo {
         create_flags: SwapchainCreateFlags::EMPTY,
         usage_flags: SwapchainUsageFlags::COLOR_ATTACHMENT | SwapchainUsageFlags::SAMPLED,
         format,
@@ -526,7 +574,13 @@ fn init_xr_session(
         face_count: 1,
         array_size: 2,
         mip_count: 1,
-    })?;
+    };
+
+    let (swapchain, foveation) = if let Some(foveation) = foveation {
+        session.create_foveated_swapchain(swapchain_create_info, foveation)?
+    } else {
+        (session.create_swapchain(swapchain_create_info)?, None)
+    };
 
     let images = swapchain.enumerate_images(device, format, resolution)?;
 
@@ -547,6 +601,7 @@ fn init_xr_session(
         images,
         graphics_info,
         blend_modes,
+        foveation,
     ))
 }
 
@@ -566,6 +621,9 @@ pub fn create_xr_session(world: &mut World) {
         .resource::<OxrEnabledExtensions>()
         .raw()
         .fb_display_refresh_rate;
+    let foveation = world
+        .get_resource::<OxrEnabledFoveationConfig>()
+        .map(|config| config.0);
     match init_xr_session(
         device.wgpu_device(),
         &instance,
@@ -575,6 +633,7 @@ pub fn create_xr_session(world: &mut World) {
         session_create_info.clone(),
         display_refresh_rate_request,
         display_refresh_rate_enabled,
+        foveation,
     ) {
         Ok((
             session,
@@ -584,6 +643,7 @@ pub fn create_xr_session(world: &mut World) {
             images,
             graphics_info,
             blend_modes,
+            foveation_profile,
         )) => {
             world.insert_resource(session.clone());
             #[cfg(target_os = "android")]
@@ -609,6 +669,9 @@ pub fn create_xr_session(world: &mut World) {
                     .clone(),
             });
             world.insert_resource(blend_modes);
+            if let Some(foveation_profile) = foveation_profile {
+                world.insert_resource(foveation_profile);
+            }
         }
         Err(e) => error!("Failed to initialize XrSession: {e}"),
     }
@@ -625,6 +688,7 @@ pub fn destroy_xr_session(world: &mut World) {
     world.remove_resource::<OxrSwapchain>();
     world.remove_resource::<OxrSwapchainImages>();
     world.remove_resource::<OxrCurrentSessionConfig>();
+    world.remove_resource::<OxrFoveationProfile>();
     world.insert_resource(XrState::Available);
 }
 

--- a/crates/bevy_openxr/src/openxr/mod.rs
+++ b/crates/bevy_openxr/src/openxr/mod.rs
@@ -23,6 +23,7 @@ pub mod environment_blend_mode;
 pub mod error;
 pub mod exts;
 pub mod features;
+pub mod foveation;
 pub mod graphics;
 pub mod helper_traits;
 pub mod init;

--- a/crates/bevy_openxr/src/openxr/mod.rs
+++ b/crates/bevy_openxr/src/openxr/mod.rs
@@ -17,6 +17,8 @@ use self::{features::handtracking::HandTrackingPlugin, reference_space::OxrRefer
 pub mod action_binding;
 pub mod action_set_attaching;
 pub mod action_set_syncing;
+#[cfg(target_os = "android")]
+pub mod android_thread_settings;
 pub mod environment_blend_mode;
 pub mod error;
 pub mod exts;

--- a/crates/bevy_openxr/src/openxr/render.rs
+++ b/crates/bevy_openxr/src/openxr/render.rs
@@ -9,22 +9,22 @@ use bevy_ecs::{
 };
 use bevy_log::{debug_span, error, info, warn};
 use bevy_render::{
-    Render, RenderApp,
     extract_resource::ExtractResourcePlugin,
     pipelined_rendering::PipelinedRenderingPlugin,
     texture::{ManualTextureView, ManualTextureViews},
     view::ExtractedView,
+    Render, RenderApp,
 };
 
 use bevy_mod_xr::{
-    camera::{Fov, XrCamera, XrProjection, XrViewInit, calculate_projection},
+    camera::{calculate_projection, Fov, XrCamera, XrProjection, XrStereoRenderMode, XrViewInit},
     session::{
         XrFirst, XrHandleEvents, XrPreDestroySession, XrRenderSystems, XrRootTransform,
         XrSessionCreated,
     },
     spaces::XrPrimaryReferenceSpace,
 };
-use bevy_transform::{TransformSystems, components::Transform};
+use bevy_transform::{components::Transform, TransformSystems};
 use openxr::ViewStateFlags;
 
 use crate::{helper_traits::ToTransform as _, init::should_run_frame_loop, resources::*};
@@ -131,14 +131,24 @@ impl Plugin for OxrRenderPlugin {
 }
 
 pub const XR_TEXTURE_INDEX: u32 = 3383858418;
+pub const XR_MULTIVIEW_TEXTURE_INDEX: u32 = XR_TEXTURE_INDEX + 2;
+
+pub fn xr_eye_texture_view_handle(index: u32) -> ManualTextureViewHandle {
+    ManualTextureViewHandle(XR_TEXTURE_INDEX + index)
+}
+
+pub fn xr_multiview_texture_view_handle() -> ManualTextureViewHandle {
+    ManualTextureViewHandle(XR_MULTIVIEW_TEXTURE_INDEX)
+}
 
 pub fn clean_views(
     mut manual_texture_views: ResMut<ManualTextureViews>,
     mut commands: Commands,
     cam_query: Query<(Entity, &XrCamera)>,
 ) {
+    manual_texture_views.remove(&xr_multiview_texture_view_handle());
     for (e, cam) in &cam_query {
-        manual_texture_views.remove(&ManualTextureViewHandle(XR_TEXTURE_INDEX + cam.0));
+        manual_texture_views.remove(&xr_eye_texture_view_handle(cam.0));
         commands.entity(e).despawn();
     }
 }
@@ -147,9 +157,13 @@ pub fn init_views<const SPAWN_CAMERAS: bool>(
     graphics_info: Res<OxrCurrentSessionConfig>,
     mut manual_texture_views: ResMut<ManualTextureViews>,
     swapchain_images: Res<OxrSwapchainImages>,
+    stereo_render_mode: Res<XrStereoRenderMode>,
     mut commands: Commands,
 ) {
     let temp_tex = swapchain_images.first().unwrap();
+    if stereo_render_mode.view_mask().is_some() {
+        add_multiview_texture_view(&mut manual_texture_views, temp_tex, &graphics_info);
+    }
     // this for loop is to easily add support for quad or mono views in the future.
     for index in 0..2 {
         let _span = debug_span!("xr_init_view").entered();
@@ -177,8 +191,7 @@ pub fn update_cameras(
     mut cameras: Query<(&mut Camera, &mut RenderTarget, &XrCamera)>,
 ) {
     for (_, mut target, xr_camera) in &mut cameras {
-        *target =
-            RenderTarget::TextureView(ManualTextureViewHandle(XR_TEXTURE_INDEX + xr_camera.0));
+        *target = RenderTarget::TextureView(xr_eye_texture_view_handle(xr_camera.0));
     }
     if frame_state.is_changed() {
         for (mut camera, _, _) in &mut cameras {
@@ -287,12 +300,17 @@ pub fn insert_texture_views(
     mut manual_texture_views: ResMut<ManualTextureViews>,
     graphics_info: Res<OxrCurrentSessionConfig>,
     frame_state: Res<OxrFrameState>,
+    stereo_render_mode: Res<XrStereoRenderMode>,
 ) {
     if !frame_state.should_render {
         return;
     }
     let index = swapchain.acquire_image().expect("Failed to acquire image");
     let image = &swapchain_images[index as usize];
+
+    if stereo_render_mode.view_mask().is_some() {
+        add_multiview_texture_view(&mut manual_texture_views, image, &graphics_info);
+    }
 
     for i in 0..2 {
         let _span = debug_span!("xr_insert_texture_view").entered();
@@ -325,7 +343,33 @@ pub fn add_texture_view(
         size: info.resolution,
         view_format: info.format,
     };
-    let handle = ManualTextureViewHandle(XR_TEXTURE_INDEX + index);
+    let handle = xr_eye_texture_view_handle(index);
+    manual_texture_views.insert(handle, view);
+    handle
+}
+
+/// Adds a 2-layer array texture view for custom stereo multiview render passes.
+///
+/// The returned view targets the same OpenXR swapchain image as the per-eye views. Render graph
+/// nodes using this view must set `RenderPassDescriptor::multiview_mask` to the mask configured
+/// by [`XrStereoRenderMode`].
+pub fn add_multiview_texture_view(
+    manual_texture_views: &mut ManualTextureViews,
+    texture: &wgpu::Texture,
+    info: &OxrCurrentSessionConfig,
+) -> ManualTextureViewHandle {
+    let view = texture.create_view(&wgpu::TextureViewDescriptor {
+        dimension: Some(wgpu::TextureViewDimension::D2Array),
+        array_layer_count: Some(2),
+        base_array_layer: 0,
+        ..Default::default()
+    });
+    let view = ManualTextureView {
+        texture_view: view.into(),
+        size: info.resolution,
+        view_format: info.format,
+    };
+    let handle = xr_multiview_texture_view_handle();
     manual_texture_views.insert(handle, view);
     handle
 }

--- a/crates/bevy_openxr/src/openxr/session.rs
+++ b/crates/bevy_openxr/src/openxr/session.rs
@@ -1,13 +1,18 @@
 use std::ffi::c_void;
+use std::ptr;
 
+use crate::foveation::{OxrFoveationConfig, OxrFoveationProfile};
 use crate::next_chain::{OxrNextChain, OxrNextChainStructBase, OxrNextChainStructProvider};
 use crate::resources::{OxrPassthrough, OxrPassthroughLayerFB, OxrSwapchain};
 use crate::types::{Result, SwapchainCreateInfo};
 use bevy_derive::Deref;
 use bevy_ecs::resource::Resource;
 use openxr::AnyGraphics;
+use openxr::sys::Handle as _;
 
-use crate::graphics::{graphics_match, GraphicsExt, GraphicsType, GraphicsWrap};
+use crate::graphics::{GraphicsExt, GraphicsType, GraphicsWrap, graphics_match};
+
+const VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT: openxr::sys::platform::VkImageCreateFlags = 0x0000_4000;
 
 /// Graphics agnostic wrapper around [openxr::Session].
 ///
@@ -67,6 +72,26 @@ impl OxrSession {
         )))
     }
 
+    /// Creates an [`OxrSwapchain`] with `XR_FB_foveation` enabled and applies
+    /// a foveation profile to it.
+    ///
+    /// On Vulkan runtimes this requests a fragment-density-map swapchain. The
+    /// returned profile is kept alive by the caller for as long as the
+    /// swapchain may use it.
+    pub fn create_foveated_swapchain(
+        &self,
+        info: SwapchainCreateInfo,
+        config: OxrFoveationConfig,
+    ) -> Result<(OxrSwapchain, Option<OxrFoveationProfile>)> {
+        Ok(graphics_match!(
+            &self.1;
+            session => {
+                let (swapchain, profile) = create_foveated_swapchain(session, info, config)?;
+                (OxrSwapchain(Api::wrap(swapchain)), profile)
+            }
+        ))
+    }
+
     /// Creates a passthrough.
     ///
     /// Requires [`XR_FB_passthrough`](https://www.khronos.org/registry/OpenXR/specs/1.0/html/xrspec.html#XR_FB_passthrough).
@@ -97,6 +122,92 @@ impl OxrSession {
             session => session.create_passthrough_layer(&passthrough.0, passthrough.1, purpose)?
         }))
     }
+}
+
+fn create_foveated_swapchain<G: GraphicsExt>(
+    session: &openxr::Session<G>,
+    info: SwapchainCreateInfo,
+    config: OxrFoveationConfig,
+) -> Result<(openxr::Swapchain<G>, Option<OxrFoveationProfile>)> {
+    let Some(format) = G::from_wgpu_format(info.format) else {
+        return Err(crate::error::OxrError::UnsupportedTextureFormat(
+            info.format,
+        ));
+    };
+
+    let mut vulkan_create_info = openxr::sys::VulkanSwapchainCreateInfoMETA {
+        ty: openxr::sys::VulkanSwapchainCreateInfoMETA::TYPE,
+        next: ptr::null(),
+        additional_create_flags: 0,
+        additional_usage_flags: 0,
+    };
+    if config.use_subsampled_layout {
+        vulkan_create_info.additional_create_flags = VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT;
+    }
+
+    let mut foveation_create_info = openxr::sys::SwapchainCreateInfoFoveationFB {
+        ty: openxr::sys::SwapchainCreateInfoFoveationFB::TYPE,
+        next: if config.use_subsampled_layout {
+            &vulkan_create_info as *const _ as *mut _
+        } else {
+            ptr::null_mut()
+        },
+        flags: if config.use_fragment_density_map {
+            openxr::sys::SwapchainCreateFoveationFlagsFB::FRAGMENT_DENSITY_MAP
+        } else {
+            openxr::sys::SwapchainCreateFoveationFlagsFB::SCALED_BIN
+        },
+    };
+
+    let create_info = openxr::sys::SwapchainCreateInfo {
+        ty: openxr::sys::SwapchainCreateInfo::TYPE,
+        next: &mut foveation_create_info as *mut _ as *const _,
+        create_flags: info.create_flags,
+        usage_flags: info.usage_flags,
+        format: G::lower_format(format),
+        sample_count: info.sample_count,
+        width: info.width,
+        height: info.height,
+        face_count: info.face_count,
+        array_size: info.array_size,
+        mip_count: info.mip_count,
+    };
+
+    let mut swapchain = openxr::sys::Swapchain::NULL;
+    let result = unsafe {
+        (session.instance().fp().create_swapchain)(session.as_raw(), &create_info, &mut swapchain)
+    };
+    if result.into_raw() < 0 {
+        return Err(result.into());
+    }
+
+    let swapchain = unsafe { openxr::Swapchain::from_raw(session.clone(), swapchain) };
+    let profile = session.create_foveation_profile(Some(openxr::FoveationLevelProfile {
+        level: config.level,
+        vertical_offset: config.vertical_offset,
+        dynamic: config.dynamic,
+    }))?;
+    let state = openxr::sys::SwapchainStateFoveationFB {
+        ty: openxr::sys::SwapchainStateFoveationFB::TYPE,
+        next: ptr::null_mut(),
+        flags: openxr::sys::SwapchainStateFoveationFlagsFB::EMPTY,
+        profile: profile.as_raw(),
+    };
+    let Some(update_swapchain) = session.instance().exts().fb_swapchain_update_state.as_ref()
+    else {
+        return Err(openxr::sys::Result::ERROR_EXTENSION_NOT_PRESENT.into());
+    };
+    let result = unsafe {
+        (update_swapchain.update_swapchain)(
+            swapchain.as_raw(),
+            &state as *const _ as *const openxr::sys::SwapchainStateBaseHeaderFB,
+        )
+    };
+    if result.into_raw() < 0 {
+        return Err(result.into());
+    }
+
+    Ok((swapchain, Some(OxrFoveationProfile(profile))))
 }
 
 pub trait OxrSessionCreateNextProvider: OxrNextChainStructProvider {}

--- a/crates/bevy_xr/src/camera.rs
+++ b/crates/bevy_xr/src/camera.rs
@@ -1,15 +1,18 @@
-use core::panic;
+use core::{num::NonZeroU32, panic};
 
 use bevy_app::{App, Plugin};
 use bevy_camera::{Camera3d, CameraProjection};
-use bevy_ecs::{component::Component, schedule::SystemSet};
+use bevy_ecs::{component::Component, resource::Resource, schedule::SystemSet};
 use bevy_math::{Mat4, Vec3A, Vec4};
 // use bevy::prelude::SystemSet;
 #[cfg(feature = "reflect")]
 use bevy_reflect::std_traits::ReflectDefault;
 #[cfg(feature = "reflect")]
 use bevy_reflect::Reflect;
-use bevy_render::extract_component::{ExtractComponent, ExtractComponentPlugin};
+use bevy_render::{
+    extract_component::{ExtractComponent, ExtractComponentPlugin},
+    extract_resource::{ExtractResource, ExtractResourcePlugin},
+};
 
 use crate::session::XrTracker;
 
@@ -17,7 +20,47 @@ pub struct XrCameraPlugin;
 
 impl Plugin for XrCameraPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(ExtractComponentPlugin::<XrCamera>::default());
+        app.init_resource::<XrStereoRenderMode>().add_plugins((
+            ExtractComponentPlugin::<XrCamera>::default(),
+            ExtractResourcePlugin::<XrStereoRenderMode>::default(),
+        ));
+    }
+}
+
+/// Selects how stereo XR views are exposed to render code.
+///
+/// [`XrStereoRenderMode::MultiPass`] is the compatibility default used by Bevy's built-in
+/// render graph today. [`XrStereoRenderMode::Multiview`] asks backends to also expose a
+/// stereo array texture view that custom render graph nodes can render to with a matching
+/// `wgpu::RenderPassDescriptor::multiview_mask`.
+#[derive(Resource, ExtractResource, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum XrStereoRenderMode {
+    /// Render each eye through a separate 2D texture view.
+    MultiPass,
+    /// Expose a single array texture view for stereo multiview rendering.
+    Multiview { view_mask: NonZeroU32 },
+}
+
+impl Default for XrStereoRenderMode {
+    fn default() -> Self {
+        Self::MultiPass
+    }
+}
+
+impl XrStereoRenderMode {
+    /// The standard two-eye OpenXR view mask: view 0 and view 1.
+    pub fn stereo_multiview() -> Self {
+        Self::Multiview {
+            view_mask: NonZeroU32::new(0b11).expect("stereo multiview mask is non-zero"),
+        }
+    }
+
+    /// Returns the render pass multiview mask, if multiview is enabled.
+    pub fn view_mask(self) -> Option<NonZeroU32> {
+        match self {
+            Self::MultiPass => None,
+            Self::Multiview { view_mask } => Some(view_mask),
+        }
     }
 }
 
@@ -196,8 +239,8 @@ pub fn calculate_projection(near_z: f32, fov: Fov) -> Mat4 {
 mod tests {
     use std::f32::{self, consts::PI};
 
-    use bevy_math::{Mat4,Vec3A};
     use bevy_camera::{CameraProjection, PerspectiveProjection};
+    use bevy_math::{Mat4, Vec3A};
 
     const TEST_VALUES: &[(f32, f32)] = &[(0.5, 100.0), (50.0, 200.0)];
 


### PR DESCRIPTION
## Summary

Adds an opt-in OpenXR foveation setup path for runtimes that expose the `XR_FB_foveation` extension family.

The new `OxrFoveationPlugin` / `OxrFoveationConfig` resource:

- requests `XR_FB_swapchain_update_state`, `XR_FB_foveation`, `XR_FB_foveation_configuration`, `XR_FB_foveation_vulkan`, and `XR_META_vulkan_swapchain_create_info`
- enables Vulkan `VK_EXT_fragment_density_map` and `VK_EXT_fragment_density_map2` device extensions when fragment-density-map foveation is requested
- creates the OpenXR swapchain with `XrSwapchainCreateInfoFoveationFB`
- optionally chains `XrVulkanSwapchainCreateInfoMETA` with `VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT`
- creates and applies an `XR_FB_foveation` profile to the swapchain
- falls back to the regular swapchain path if the runtime does not expose every required OpenXR extension

This also fixes the workspace dependency version pins from `0.5.0` to `0.6.0`, which currently prevents checking the workspace from `main`.

## Caveat

Meta's native Vulkan FFR documentation also describes retrieving fragment-density-map images and using them as Vulkan render-pass fragment density map attachments. Current `wgpu` render pass APIs do not expose that attachment directly, so this PR should be treated as the OpenXR swapchain/profile foundation. Apps should validate visual quality and GPU timing on target headsets before relying on a performance reduction.

## Validation

- `CARGO_TARGET_DIR=target/codex-openxr-ffr cargo check -p bevy_mod_openxr`
- `CARGO_TARGET_DIR=target/codex-openxr-ffr cargo check -p bevy_mod_openxr --features window_support`
- Downstream compile smoke against a Quest/OpenXR Bevy client using Cargo config patches to this branch:
  - `CARGO_TARGET_DIR=target/codex-bevy-client CARGO_INCREMENTAL=0 cargo check -p bevy-game-client --features quest-vr --lib --config 'patch.crates-io.bevy_mod_openxr.path="/tmp/bevy_oxr-ffr-pr-clean/crates/bevy_openxr"' --config 'patch.crates-io.bevy_mod_xr.path="/tmp/bevy_oxr-ffr-pr-clean/crates/bevy_xr"'`
- `git diff --check`

Android target notes:

- `cargo check -p bevy_mod_openxr --target aarch64-linux-android` reaches the existing `android-activity` dependency and fails because no `game-activity`/`native-activity` feature is enabled for that direct package check.
- `cargo check -p bevy_openxr_android --target aarch64-linux-android` proceeds through the Android activity setup but fails on the example's host-side `openssl-sys`/`pkg-config` requirement from build dependencies in the test environment.
