### PR TITLE
Add opt-in OpenXR multiview target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1186,7 +1186,7 @@ checksum = "bff34eb29ff4b8a8688bc7299f14fb6b597461ca80fec03ed7d22939ab33e48f"
 
 [[package]]
 name = "bevy_mod_openxr"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "android-activity",
  "android_system_properties",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_mod_xr"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bevy_app",
  "bevy_camera",
@@ -1243,7 +1243,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_openxr_android"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bevy",
  "bevy_mod_openxr",
@@ -1885,7 +1885,7 @@ dependencies = [
 
 [[package]]
 name = "bevy_xr_utils"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bevy",
  "bevy_app",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,9 @@ bevy_derive = { version = "0.19", default-features = false }
 bevy_platform = { version = "0.19", default-features = false }
 
 
-bevy_mod_xr = { path = "crates/bevy_xr", version = "0.5.0" }
-bevy_mod_openxr = { path = "crates/bevy_openxr", version = "0.5.0" }
-bevy_xr_utils = { path = "crates/bevy_xr_utils", version = "0.5.0" }
+bevy_mod_xr = { path = "crates/bevy_xr", version = "0.6.0" }
+bevy_mod_openxr = { path = "crates/bevy_openxr", version = "0.6.0" }
+bevy_xr_utils = { path = "crates/bevy_xr_utils", version = "0.6.0" }
 openxr = "0.21.1"
 thiserror = "2.0.3"
 wgpu = "29"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A crate for adding openxr (and in the future webxr) support to Bevy.
 
 To see it in action run the example in `crates/bevy_openxr/examples` with `cargo run -p bevy_mod_openxr --example 3d_scene`
 
+The OpenXR backend can also expose an opt-in stereo multiview swapchain view for custom render graph nodes. See `cargo run -p bevy_mod_openxr --example multiview` and the `bevy_mod_openxr` README for details.
+
 ## Discord
 
 Come hang out if you have questions or issues 
@@ -33,4 +35,3 @@ at your option. This means you can select the license you prefer!
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall
 be dual licensed as above, without any additional terms or conditions.
-

--- a/crates/bevy_openxr/README.md
+++ b/crates/bevy_openxr/README.md
@@ -2,5 +2,32 @@
 
 This is the OpenXR backend for bevy_mod_xr for more info see the [repo](https://github.com/awtterpip/bevy_oxr)
 
+## Stereo multiview
+
+The default stereo path renders each eye through its own 2D texture view. This is the most compatible mode and is what Bevy's built-in 3D render graph expects today.
+
+Apps that provide their own multiview-aware render graph nodes can ask the OpenXR backend to also expose a 2-layer array texture view for the current stereo swapchain image:
+
+```rust
+use bevy::prelude::*;
+use bevy_mod_openxr::add_xr_plugins;
+use bevy_mod_xr::camera::XrStereoRenderMode;
+
+fn main() {
+    App::new()
+        .insert_resource(XrStereoRenderMode::stereo_multiview())
+        .add_plugins(add_xr_plugins(DefaultPlugins))
+        .run();
+}
+```
+
+The multiview texture view is available from `bevy_mod_openxr::render::xr_multiview_texture_view_handle()`. Custom render passes should use that manual texture view and set `wgpu::RenderPassDescriptor::multiview_mask` to `XrStereoRenderMode::view_mask()`.
+
+The render device must support `wgpu::Features::MULTIVIEW` before a custom pass uses a non-empty multiview mask.
+
+This does not automatically convert Bevy's built-in PBR or core render passes to single-pass stereo. Those passes still need multiview-aware render graph integration and shaders that select per-eye data with the platform view index.
+
+See `cargo run -p bevy_mod_openxr --example multiview` for a minimal setup example.
+
 ![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExY2FlOXJrOG1pbzFkYTVjZHIybndqamF1a2YwZHU3dXgyZGcwdmFzMiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/CHbQyXOT5yZZ1VQRh7/giphy-downsized-large.gif)
 ![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbHVmZXc2b3VhcGE2eHE2c2Y3NDR6cXNibHdjNjk5MmtyOHlkMXkwZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Hsvp5el2o7tzgOf9GQ/giphy-downsized-large.gif)

--- a/crates/bevy_openxr/examples/multiview.rs
+++ b/crates/bevy_openxr/examples/multiview.rs
@@ -1,0 +1,57 @@
+//! Requests OpenXR stereo multiview resources.
+//!
+//! Bevy's built-in 3D render graph still renders through the per-eye texture views. Custom render
+//! graph nodes can target `xr_multiview_texture_view_handle()` and set the render pass
+//! `multiview_mask` to the configured `XrStereoRenderMode::view_mask()`.
+
+use bevy::{prelude::*, render::pipelined_rendering::PipelinedRenderingPlugin};
+use bevy_mod_openxr::{
+    add_xr_plugins,
+    render::{xr_multiview_texture_view_handle, XR_MULTIVIEW_TEXTURE_INDEX},
+};
+use bevy_mod_xr::camera::XrStereoRenderMode;
+
+fn main() -> AppExit {
+    App::new()
+        .insert_resource(XrStereoRenderMode::stereo_multiview())
+        .add_plugins(add_xr_plugins(
+            DefaultPlugins.build().disable::<PipelinedRenderingPlugin>(),
+        ))
+        .add_systems(Startup, (log_multiview_target, setup))
+        .run()
+}
+
+fn log_multiview_target(stereo_render_mode: Res<XrStereoRenderMode>) {
+    let _handle = xr_multiview_texture_view_handle();
+    info!(
+        "OpenXR stereo multiview target requested at manual texture view index {}; pass mask: {:?}",
+        XR_MULTIVIEW_TEXTURE_INDEX,
+        stereo_render_mode.view_mask()
+    );
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    commands.spawn((
+        Mesh3d(meshes.add(Circle::new(4.0))),
+        MeshMaterial3d(materials.add(Color::WHITE)),
+        Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
+    ));
+
+    commands.spawn((
+        Mesh3d(meshes.add(Cuboid::new(1.0, 1.0, 1.0))),
+        MeshMaterial3d(materials.add(Color::srgb_u8(124, 144, 255))),
+        Transform::from_xyz(0.0, 0.5, 0.0),
+    ));
+
+    commands.spawn((
+        PointLight {
+            shadow_maps_enabled: true,
+            ..default()
+        },
+        Transform::from_xyz(4.0, 8.0, 4.0),
+    ));
+}

--- a/crates/bevy_openxr/src/openxr/render.rs
+++ b/crates/bevy_openxr/src/openxr/render.rs
@@ -9,22 +9,22 @@ use bevy_ecs::{
 };
 use bevy_log::{debug_span, error, info, warn};
 use bevy_render::{
-    Render, RenderApp,
     extract_resource::ExtractResourcePlugin,
     pipelined_rendering::PipelinedRenderingPlugin,
     texture::{ManualTextureView, ManualTextureViews},
     view::ExtractedView,
+    Render, RenderApp,
 };
 
 use bevy_mod_xr::{
-    camera::{Fov, XrCamera, XrProjection, XrViewInit, calculate_projection},
+    camera::{calculate_projection, Fov, XrCamera, XrProjection, XrStereoRenderMode, XrViewInit},
     session::{
         XrFirst, XrHandleEvents, XrPreDestroySession, XrRenderSystems, XrRootTransform,
         XrSessionCreated,
     },
     spaces::XrPrimaryReferenceSpace,
 };
-use bevy_transform::{TransformSystems, components::Transform};
+use bevy_transform::{components::Transform, TransformSystems};
 use openxr::ViewStateFlags;
 
 use crate::{helper_traits::ToTransform as _, init::should_run_frame_loop, resources::*};
@@ -131,14 +131,24 @@ impl Plugin for OxrRenderPlugin {
 }
 
 pub const XR_TEXTURE_INDEX: u32 = 3383858418;
+pub const XR_MULTIVIEW_TEXTURE_INDEX: u32 = XR_TEXTURE_INDEX + 2;
+
+pub fn xr_eye_texture_view_handle(index: u32) -> ManualTextureViewHandle {
+    ManualTextureViewHandle(XR_TEXTURE_INDEX + index)
+}
+
+pub fn xr_multiview_texture_view_handle() -> ManualTextureViewHandle {
+    ManualTextureViewHandle(XR_MULTIVIEW_TEXTURE_INDEX)
+}
 
 pub fn clean_views(
     mut manual_texture_views: ResMut<ManualTextureViews>,
     mut commands: Commands,
     cam_query: Query<(Entity, &XrCamera)>,
 ) {
+    manual_texture_views.remove(&xr_multiview_texture_view_handle());
     for (e, cam) in &cam_query {
-        manual_texture_views.remove(&ManualTextureViewHandle(XR_TEXTURE_INDEX + cam.0));
+        manual_texture_views.remove(&xr_eye_texture_view_handle(cam.0));
         commands.entity(e).despawn();
     }
 }
@@ -147,9 +157,13 @@ pub fn init_views<const SPAWN_CAMERAS: bool>(
     graphics_info: Res<OxrCurrentSessionConfig>,
     mut manual_texture_views: ResMut<ManualTextureViews>,
     swapchain_images: Res<OxrSwapchainImages>,
+    stereo_render_mode: Res<XrStereoRenderMode>,
     mut commands: Commands,
 ) {
     let temp_tex = swapchain_images.first().unwrap();
+    if stereo_render_mode.view_mask().is_some() {
+        add_multiview_texture_view(&mut manual_texture_views, temp_tex, &graphics_info);
+    }
     // this for loop is to easily add support for quad or mono views in the future.
     for index in 0..2 {
         let _span = debug_span!("xr_init_view").entered();
@@ -177,8 +191,7 @@ pub fn update_cameras(
     mut cameras: Query<(&mut Camera, &mut RenderTarget, &XrCamera)>,
 ) {
     for (_, mut target, xr_camera) in &mut cameras {
-        *target =
-            RenderTarget::TextureView(ManualTextureViewHandle(XR_TEXTURE_INDEX + xr_camera.0));
+        *target = RenderTarget::TextureView(xr_eye_texture_view_handle(xr_camera.0));
     }
     if frame_state.is_changed() {
         for (mut camera, _, _) in &mut cameras {
@@ -287,12 +300,17 @@ pub fn insert_texture_views(
     mut manual_texture_views: ResMut<ManualTextureViews>,
     graphics_info: Res<OxrCurrentSessionConfig>,
     frame_state: Res<OxrFrameState>,
+    stereo_render_mode: Res<XrStereoRenderMode>,
 ) {
     if !frame_state.should_render {
         return;
     }
     let index = swapchain.acquire_image().expect("Failed to acquire image");
     let image = &swapchain_images[index as usize];
+
+    if stereo_render_mode.view_mask().is_some() {
+        add_multiview_texture_view(&mut manual_texture_views, image, &graphics_info);
+    }
 
     for i in 0..2 {
         let _span = debug_span!("xr_insert_texture_view").entered();
@@ -325,7 +343,33 @@ pub fn add_texture_view(
         size: info.resolution,
         view_format: info.format,
     };
-    let handle = ManualTextureViewHandle(XR_TEXTURE_INDEX + index);
+    let handle = xr_eye_texture_view_handle(index);
+    manual_texture_views.insert(handle, view);
+    handle
+}
+
+/// Adds a 2-layer array texture view for custom stereo multiview render passes.
+///
+/// The returned view targets the same OpenXR swapchain image as the per-eye views. Render graph
+/// nodes using this view must set `RenderPassDescriptor::multiview_mask` to the mask configured
+/// by [`XrStereoRenderMode`].
+pub fn add_multiview_texture_view(
+    manual_texture_views: &mut ManualTextureViews,
+    texture: &wgpu::Texture,
+    info: &OxrCurrentSessionConfig,
+) -> ManualTextureViewHandle {
+    let view = texture.create_view(&wgpu::TextureViewDescriptor {
+        dimension: Some(wgpu::TextureViewDimension::D2Array),
+        array_layer_count: Some(2),
+        base_array_layer: 0,
+        ..Default::default()
+    });
+    let view = ManualTextureView {
+        texture_view: view.into(),
+        size: info.resolution,
+        view_format: info.format,
+    };
+    let handle = xr_multiview_texture_view_handle();
     manual_texture_views.insert(handle, view);
     handle
 }

--- a/crates/bevy_xr/src/camera.rs
+++ b/crates/bevy_xr/src/camera.rs
@@ -1,15 +1,18 @@
-use core::panic;
+use core::{num::NonZeroU32, panic};
 
 use bevy_app::{App, Plugin};
 use bevy_camera::{Camera3d, CameraProjection};
-use bevy_ecs::{component::Component, schedule::SystemSet};
+use bevy_ecs::{component::Component, resource::Resource, schedule::SystemSet};
 use bevy_math::{Mat4, Vec3A, Vec4};
 // use bevy::prelude::SystemSet;
 #[cfg(feature = "reflect")]
 use bevy_reflect::std_traits::ReflectDefault;
 #[cfg(feature = "reflect")]
 use bevy_reflect::Reflect;
-use bevy_render::extract_component::{ExtractComponent, ExtractComponentPlugin};
+use bevy_render::{
+    extract_component::{ExtractComponent, ExtractComponentPlugin},
+    extract_resource::{ExtractResource, ExtractResourcePlugin},
+};
 
 use crate::session::XrTracker;
 
@@ -17,7 +20,47 @@ pub struct XrCameraPlugin;
 
 impl Plugin for XrCameraPlugin {
     fn build(&self, app: &mut App) {
-        app.add_plugins(ExtractComponentPlugin::<XrCamera>::default());
+        app.init_resource::<XrStereoRenderMode>().add_plugins((
+            ExtractComponentPlugin::<XrCamera>::default(),
+            ExtractResourcePlugin::<XrStereoRenderMode>::default(),
+        ));
+    }
+}
+
+/// Selects how stereo XR views are exposed to render code.
+///
+/// [`XrStereoRenderMode::MultiPass`] is the compatibility default used by Bevy's built-in
+/// render graph today. [`XrStereoRenderMode::Multiview`] asks backends to also expose a
+/// stereo array texture view that custom render graph nodes can render to with a matching
+/// `wgpu::RenderPassDescriptor::multiview_mask`.
+#[derive(Resource, ExtractResource, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum XrStereoRenderMode {
+    /// Render each eye through a separate 2D texture view.
+    MultiPass,
+    /// Expose a single array texture view for stereo multiview rendering.
+    Multiview { view_mask: NonZeroU32 },
+}
+
+impl Default for XrStereoRenderMode {
+    fn default() -> Self {
+        Self::MultiPass
+    }
+}
+
+impl XrStereoRenderMode {
+    /// The standard two-eye OpenXR view mask: view 0 and view 1.
+    pub fn stereo_multiview() -> Self {
+        Self::Multiview {
+            view_mask: NonZeroU32::new(0b11).expect("stereo multiview mask is non-zero"),
+        }
+    }
+
+    /// Returns the render pass multiview mask, if multiview is enabled.
+    pub fn view_mask(self) -> Option<NonZeroU32> {
+        match self {
+            Self::MultiPass => None,
+            Self::Multiview { view_mask } => Some(view_mask),
+        }
     }
 }
 
@@ -196,8 +239,8 @@ pub fn calculate_projection(near_z: f32, fov: Fov) -> Mat4 {
 mod tests {
     use std::f32::{self, consts::PI};
 
-    use bevy_math::{Mat4,Vec3A};
     use bevy_camera::{CameraProjection, PerspectiveProjection};
+    use bevy_math::{Mat4, Vec3A};
 
     const TEST_VALUES: &[(f32, f32)] = &[(0.5, 100.0), (50.0, 200.0)];
 


### PR DESCRIPTION
## Summary
- add an extracted `XrStereoRenderMode` resource so apps can opt in to stereo multiview resources
- expose a 2-layer OpenXR swapchain `D2Array` manual texture view for custom multiview render graph nodes while keeping the existing per-eye views
- document the scope and add a minimal `multiview` example
- align workspace path dependency versions with the existing 0.6.0 package version so the workspace checks cleanly

## Notes
This does not automatically convert Bevy's built-in PBR/core render passes to single-pass stereo. Custom render graph nodes still need to target the multiview manual texture view, set `RenderPassDescriptor::multiview_mask`, and provide per-eye shader data.

## Checks
- `cargo check -p bevy_mod_xr -p bevy_mod_openxr --example multiview`
- `cargo check -p bevy_mod_openxr --example 3d_scene`
