### PR TITLE
Add OpenXR display refresh rate request resource

### DIFF
--- a/crates/bevy_openxr/src/openxr/init.rs
+++ b/crates/bevy_openxr/src/openxr/init.rs
@@ -82,6 +82,10 @@ pub struct OxrInitPlugin {
     pub synchronous_pipeline_compilation: bool,
     pub render_debug_flags: RenderDebugFlags,
 }
+
+#[derive(Clone, Copy, Debug, Resource)]
+pub struct OxrDisplayRefreshRateRequest(pub f32);
+
 impl Default for OxrInitPlugin {
     fn default() -> Self {
         Self {
@@ -377,6 +381,8 @@ fn init_xr_session(
         resolutions,
     }: OxrSessionConfig,
     graphics_info: SessionGraphicsCreateInfo,
+    display_refresh_rate_request: Option<f32>,
+    display_refresh_rate_enabled: bool,
 ) -> OxrResult<(
     OxrSession,
     OxrFrameWaiter,
@@ -388,6 +394,39 @@ fn init_xr_session(
 )> {
     let (session, frame_waiter, frame_stream) =
         unsafe { instance.create_session(system_id, graphics_info, chain)? };
+
+    if let Some(requested_hz) = display_refresh_rate_request {
+        if display_refresh_rate_enabled {
+            match session.enumerate_display_refresh_rates() {
+                Ok(rates) => info!(
+                    "OpenXR display refresh available_rates={rates:?} requested_hz={requested_hz:.3}"
+                ),
+                Err(err) => warn!(
+                    "OpenXR display refresh enumerate failed requested_hz={requested_hz:.3} error={err}"
+                ),
+            }
+            match session.get_display_refresh_rate() {
+                Ok(current_hz) => info!(
+                    "OpenXR display refresh before_request current_hz={current_hz:.3} requested_hz={requested_hz:.3}"
+                ),
+                Err(err) => warn!(
+                    "OpenXR display refresh get before request failed requested_hz={requested_hz:.3} error={err}"
+                ),
+            }
+            match session.request_display_refresh_rate(requested_hz) {
+                Ok(()) => {
+                    info!("OpenXR display refresh request submitted requested_hz={requested_hz:.3}")
+                }
+                Err(err) => warn!(
+                    "OpenXR display refresh request failed requested_hz={requested_hz:.3} error={err}"
+                ),
+            }
+        } else {
+            warn!(
+                "OpenXR display refresh request skipped; XR_FB_display_refresh_rate unavailable requested_hz={requested_hz:.3}"
+            );
+        }
+    }
 
     // TODO!() support other view configurations
     let available_view_configurations = instance.enumerate_view_configurations(system_id)?;
@@ -497,6 +536,13 @@ pub fn create_xr_session(world: &mut World) {
     let session_config = world.resource::<OxrSessionConfig>();
     let session_create_info = world.non_send::<SessionGraphicsCreateInfo>();
     let system_id = world.resource::<OxrSystemId>();
+    let display_refresh_rate_request = world
+        .get_resource::<OxrDisplayRefreshRateRequest>()
+        .map(|request| request.0);
+    let display_refresh_rate_enabled = world
+        .resource::<OxrEnabledExtensions>()
+        .raw()
+        .fb_display_refresh_rate;
     match init_xr_session(
         device.wgpu_device(),
         instance,
@@ -504,6 +550,8 @@ pub fn create_xr_session(world: &mut World) {
         &mut chain,
         session_config.clone(),
         session_create_info.clone(),
+        display_refresh_rate_request,
+        display_refresh_rate_enabled,
     ) {
         Ok((
             session,


### PR DESCRIPTION
## Summary
- add an `OxrDisplayRefreshRateRequest` resource to request an OpenXR display refresh rate after session creation
- use `XR_FB_display_refresh_rate` only when the runtime enabled it
- log available/current rates and request failures so apps can diagnose runtime behavior

## Why
Quest and other OpenXR Android apps often need to request a concrete display rate such as 72 Hz, 80 Hz, 90 Hz, or 120 Hz for benchmark runs and production frame pacing. The `openxr` crate already exposes the refresh-rate extension methods on the session; this adds a Bevy resource-level hook in the OpenXR backend so apps can request the rate without forking session creation.

## Usage
```rust
app.insert_resource(OxrDisplayRefreshRateRequest(90.0));
```

The app should also request/enable `XR_FB_display_refresh_rate` through its `OxrExtensions`; if the runtime does not expose it, the request is skipped with a warning.

## Checks
- Attempted `cargo check -p bevy_mod_openxr --example 3d_scene` on a clean `upstream/main` branch, but Cargo fails before compiling this change because `bevy_mod_openxr v0.6.0` still depends on workspace `bevy_mod_xr = ^0.5.0` while the workspace package is `0.6.0`.
- The same change was checked successfully on `brianconnoly:main` after that existing workspace dependency version mismatch was fixed.
